### PR TITLE
Add email login flow with cookie persistence

### DIFF
--- a/cmd/careme/html/home.html
+++ b/cmd/careme/html/home.html
@@ -9,7 +9,7 @@
     .card{background:#fff;padding:1.5rem;border-radius:8px;max-width:720px;margin:0 auto;box-shadow:0 2px 8px rgba(0,0,0,0.06)}
     h1{margin-top:0}
     form{margin-top:1rem}
-    input[type=text]{padding:0.5rem;width:200px;margin-right:0.5rem}
+    input[type=text],input[type=email]{padding:0.5rem;width:200px;margin-right:0.5rem}
     button{padding:0.5rem 0.75rem}
   </style>
   {{.ClarityScript}}
@@ -26,11 +26,27 @@
 </pre>
     </div>
 
+    {{if .User}}
+    <div style="margin-bottom:1rem">
+      <p style="margin:0">Signed in as <strong>{{.User.Email}}</strong></p>
+      <small>User ID: <code>{{.User.ID}}</code></small>
+      <form method="POST" action="/logout" style="margin-top:0.5rem">
+        <button type="submit">Sign out</button>
+      </form>
+    </div>
+
     <form method="GET" action="/locations">
       <label for="zip">Enter ZIP code to pick a nearby store:</label><br>
       <input type="text" id="zip" name="zip" placeholder="e.g. 90210" required pattern="\d{5}">
       <button type="submit">Find Stores</button>
     </form>
+    {{else}}
+    <form method="POST" action="/login">
+      <label for="email">Enter your email to continue:</label><br>
+      <input type="email" id="email" name="email" placeholder="you@example.com" required>
+      <button type="submit">Continue</button>
+    </form>
+    {{end}}
   </div>
 </body>
 </html>

--- a/cmd/careme/web.go
+++ b/cmd/careme/web.go
@@ -6,13 +6,18 @@ import (
 	"careme/internal/html"
 	"careme/internal/locations"
 	"careme/internal/recipes"
+	"careme/internal/users"
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 )
+
+const sessionDuration = 365 * 24 * time.Hour
 
 func runServer(cfg *config.Config, addr string) error {
 
@@ -24,20 +29,68 @@ func runServer(cfg *config.Config, addr string) error {
 		return fmt.Errorf("failed to create cache: %w", err)
 	}
 
-	data := struct {
-		ClarityScript template.HTML
-	}{
-		ClarityScript: html.ClarityScript(cfg),
-	}
+	clarityScript := html.ClarityScript(cfg)
+	userStorage := users.NewStorage(cfg.Users.StoragePath)
 
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		currentUser, err := userFromCookie(r, userStorage)
+		if err != nil {
+			if errors.Is(err, users.ErrNotFound) {
+				clearUserCookie(w)
+			} else {
+				log.Printf("failed to load user from cookie: %v", err)
+				http.Error(w, "unable to load account", http.StatusInternalServerError)
+				return
+			}
+		}
+		data := struct {
+			ClarityScript template.HTML
+			User          *users.User
+		}{
+			ClarityScript: clarityScript,
+			User:          currentUser,
+		}
 		if err := homeTmpl.Execute(w, data); err != nil {
 			log.Printf("home template execute error: %v", err)
 			http.Error(w, "template error", http.StatusInternalServerError)
 		}
 	})
+
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form submission", http.StatusBadRequest)
+			return
+		}
+		email := strings.TrimSpace(r.FormValue("email"))
+		if email == "" {
+			http.Error(w, "email is required", http.StatusBadRequest)
+			return
+		}
+		user, err := userStorage.FindOrCreateByEmail(email)
+		if err != nil {
+			log.Printf("failed to find or create user: %v", err)
+			http.Error(w, "unable to sign in", http.StatusInternalServerError)
+			return
+		}
+		setUserCookie(w, user.ID)
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	})
+
+	mux.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		clearUserCookie(w)
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	})
+
 	generator, err := recipes.NewGenerator(cfg, cache)
 	if err != nil {
 		return fmt.Errorf("failed to create recipe generator: %w", err)
@@ -46,7 +99,23 @@ func runServer(cfg *config.Config, addr string) error {
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))
 	})
+
 	mux.HandleFunc("/locations", func(w http.ResponseWriter, r *http.Request) {
+		currentUser, err := userFromCookie(r, userStorage)
+		if err != nil {
+			if errors.Is(err, users.ErrNotFound) {
+				clearUserCookie(w)
+				http.Redirect(w, r, "/", http.StatusSeeOther)
+				return
+			}
+			log.Printf("failed to load user for locations: %v", err)
+			http.Error(w, "unable to load account", http.StatusInternalServerError)
+			return
+		}
+		if currentUser == nil {
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+			return
+		}
 		zip := r.URL.Query().Get("zip")
 		if zip == "" {
 			log.Printf("no zip code provided to /locations")
@@ -64,6 +133,21 @@ func runServer(cfg *config.Config, addr string) error {
 	})
 
 	mux.HandleFunc("/recipes", func(w http.ResponseWriter, r *http.Request) {
+		currentUser, err := userFromCookie(r, userStorage)
+		if err != nil {
+			if errors.Is(err, users.ErrNotFound) {
+				clearUserCookie(w)
+				http.Redirect(w, r, "/", http.StatusSeeOther)
+				return
+			}
+			log.Printf("failed to load user for recipes: %v", err)
+			http.Error(w, "unable to load account", http.StatusInternalServerError)
+			return
+		}
+		if currentUser == nil {
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+			return
+		}
 		ctx := r.Context()
 		loc := r.URL.Query().Get("location")
 		if loc == "" {
@@ -108,7 +192,12 @@ func runServer(cfg *config.Config, addr string) error {
 		}()
 
 		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
-		if err := spinnerTmpl.Execute(w, data); err != nil {
+		spinnerData := struct {
+			ClarityScript template.HTML
+		}{
+			ClarityScript: clarityScript,
+		}
+		if err := spinnerTmpl.Execute(w, spinnerData); err != nil {
 			log.Printf("home template execute error: %v", err)
 			http.Error(w, "template error", http.StatusInternalServerError)
 		}
@@ -116,4 +205,46 @@ func runServer(cfg *config.Config, addr string) error {
 
 	log.Printf("Serving Careme on %s", addr)
 	return http.ListenAndServe(addr, mux)
+}
+
+func setUserCookie(w http.ResponseWriter, userID string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     users.CookieName,
+		Value:    userID,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Expires:  time.Now().Add(sessionDuration),
+		MaxAge:   int(sessionDuration / time.Second),
+	})
+}
+
+func clearUserCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     users.CookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+		Expires:  time.Unix(0, 0),
+	})
+}
+
+func userFromCookie(r *http.Request, store *users.Storage) (*users.User, error) {
+	cookie, err := r.Cookie(users.CookieName)
+	if err != nil {
+		if errors.Is(err, http.ErrNoCookie) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if cookie.Value == "" {
+		return nil, nil
+	}
+	user, err := store.GetByID(cookie.Value)
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	AI      AIConfig      `json:"ai"`
 	Kroger  KrogerConfig  `json:"kroger"`
 	History HistoryConfig `json:"history"`
+	Users   UsersConfig   `json:"users"`
 	Clarity ClarityConfig `json:"clarity"`
 }
 
@@ -26,6 +27,10 @@ type KrogerConfig struct {
 type HistoryConfig struct {
 	StoragePath   string `json:"storage_path"`
 	RetentionDays int    `json:"retention_days"`
+}
+
+type UsersConfig struct {
+	StoragePath string `json:"storage_path"`
 }
 
 type ClarityConfig struct {
@@ -46,6 +51,9 @@ func Load() (*Config, error) {
 		History: HistoryConfig{
 			StoragePath:   getEnvOrDefault("HISTORY_PATH", "./data/history.json"),
 			RetentionDays: 14,
+		},
+		Users: UsersConfig{
+			StoragePath: getEnvOrDefault("USERS_PATH", "./data/users.json"),
 		},
 		Clarity: ClarityConfig{
 			ProjectID: os.Getenv("CLARITY_PROJECT_ID"),

--- a/internal/users/storage.go
+++ b/internal/users/storage.go
@@ -1,0 +1,158 @@
+package users
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type User struct {
+	ID        string    `json:"id"`
+	Email     string    `json:"email"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type storageFile struct {
+	Users []User `json:"users"`
+}
+
+type Storage struct {
+	path string
+	mu   sync.Mutex
+}
+
+var (
+	ErrNotFound = errors.New("user not found")
+)
+
+const CookieName = "careme_user"
+
+func NewStorage(path string) *Storage {
+	return &Storage{path: path}
+}
+
+func (s *Storage) GetByID(id string) (*User, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	users, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	for _, user := range users.Users {
+		if user.ID == id {
+			u := user
+			return &u, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (s *Storage) GetByEmail(email string) (*User, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	normalized := normalizeEmail(email)
+	users, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	for _, user := range users.Users {
+		if user.Email == normalized {
+			u := user
+			return &u, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (s *Storage) FindOrCreateByEmail(email string) (*User, error) {
+	normalized := normalizeEmail(email)
+	if normalized == "" {
+		return nil, fmt.Errorf("email is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	users, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range users.Users {
+		if user.Email == normalized {
+			u := user
+			return &u, nil
+		}
+	}
+
+	newUser := User{
+		ID:        newUserID(),
+		Email:     normalized,
+		CreatedAt: time.Now(),
+	}
+	users.Users = append(users.Users, newUser)
+	if err := s.save(users); err != nil {
+		return nil, err
+	}
+	return &newUser, nil
+}
+
+func (s *Storage) load() (storageFile, error) {
+	var users storageFile
+	if err := s.ensureDir(); err != nil {
+		return users, err
+	}
+	if _, err := os.Stat(s.path); os.IsNotExist(err) {
+		return users, nil
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return users, fmt.Errorf("failed to read users file: %w", err)
+	}
+	if len(data) == 0 {
+		return users, nil
+	}
+	if err := json.Unmarshal(data, &users); err != nil {
+		return users, fmt.Errorf("failed to decode users: %w", err)
+	}
+	return users, nil
+}
+
+func (s *Storage) save(users storageFile) error {
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(users, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode users: %w", err)
+	}
+	if err := os.WriteFile(s.path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write users file: %w", err)
+	}
+	return nil
+}
+
+func (s *Storage) ensureDir() error {
+	return os.MkdirAll(filepath.Dir(s.path), 0o755)
+}
+
+func normalizeEmail(email string) string {
+	return strings.TrimSpace(strings.ToLower(email))
+}
+
+func newUserID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Errorf("failed to generate user id: %w", err))
+	}
+	return hex.EncodeToString(b)
+}


### PR DESCRIPTION
## Summary
- add a simple user storage package to persist email sign-ins and expose a shared cookie name
- extend the web server and home template with login, logout, and cookie management that gates location/recipe routes
- add configuration for the user storage path so cookies can be resolved on restart

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d227221c488329b5af3925458b9f5f