### PR TITLE
Add Clerk hosted sign-in/up integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.24.6
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 
-require github.com/samber/lo v1.51.0
+require (
+	github.com/clerk/clerk-sdk-go/v2 v2.0.0
+	github.com/samber/lo v1.51.0
+)
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -1,0 +1,127 @@
+package auth
+
+import (
+	"careme/internal/config"
+	"careme/internal/users"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/clerk/clerk-sdk-go/v2"
+)
+
+const clerkSessionCookie = "__session"
+
+type Manager struct {
+	cfg        *config.Config
+	store      *users.Storage
+	client     *clerk.Client
+	useOffline bool
+}
+
+func NewManager(cfg *config.Config, store *users.Storage) (*Manager, error) {
+	if cfg == nil {
+		return nil, errors.New("auth config is required")
+	}
+	if store == nil {
+		return nil, errors.New("user storage is required")
+	}
+
+	manager := &Manager{
+		cfg:   cfg,
+		store: store,
+	}
+
+	if cfg.Mocks.Enable && cfg.Clerk.SecretKey == "" {
+		manager.useOffline = true
+		return manager, nil
+	}
+
+	client, err := clerk.NewClient(clerk.WithSecretKey(cfg.Clerk.SecretKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize clerk client: %w", err)
+	}
+
+	manager.client = client
+	return manager, nil
+}
+
+func (m *Manager) Offline() bool {
+	return m.useOffline
+}
+
+func (m *Manager) SignInURL() string {
+	return m.cfg.Clerk.SignInURL
+}
+
+func (m *Manager) SignUpURL() string {
+	return m.cfg.Clerk.SignUpURL
+}
+
+func (m *Manager) SignOutURL() string {
+	return m.cfg.Clerk.SignOutURL
+}
+
+func (m *Manager) CurrentUser(r *http.Request) (*users.User, error) {
+	if m.useOffline {
+		return users.FromRequest(r, m.store)
+	}
+
+	token := sessionTokenFromRequest(r)
+	if token == "" {
+		return nil, users.ErrNotFound
+	}
+
+	claims, err := clerk.VerifyToken(token, &clerk.VerifyTokenOptions{SecretKey: m.cfg.Clerk.SecretKey})
+	if err != nil {
+		return nil, err
+	}
+	userID := claims.Subject
+	if userID == "" {
+		return nil, users.ErrNotFound
+	}
+
+	email := claims.Email
+	if email == "" {
+		email, err = m.fetchPrimaryEmail(r.Context(), userID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return m.store.FindOrCreateByID(userID, email)
+}
+
+func (m *Manager) fetchPrimaryEmail(ctx context.Context, userID string) (string, error) {
+	if m.client == nil {
+		return "", errors.New("clerk client unavailable")
+	}
+	user, err := m.client.Users.Get(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("failed to load clerk user: %w", err)
+	}
+	if user.PrimaryEmailAddressID != "" {
+		for _, email := range user.EmailAddresses {
+			if email.ID == user.PrimaryEmailAddressID {
+				return email.EmailAddress, nil
+			}
+		}
+	}
+	if len(user.EmailAddresses) > 0 {
+		return user.EmailAddresses[0].EmailAddress, nil
+	}
+	return "", errors.New("clerk user missing email address")
+}
+
+func sessionTokenFromRequest(r *http.Request) string {
+	authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+	if strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+		return strings.TrimSpace(authHeader[7:])
+	}
+	if cookie, err := r.Cookie(clerkSessionCookie); err == nil {
+		return cookie.Value
+	}
+	return ""
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	AI     AIConfig     `json:"ai"`
 	Kroger KrogerConfig `json:"kroger"`
 	Mocks  MockConfig   `json:"mocks"`
+	Clerk  ClerkConfig  `json:"clerk"`
 }
 
 type AIConfig struct {
@@ -24,6 +25,18 @@ type MockConfig struct {
 	Enable bool
 }
 
+type ClerkConfig struct {
+	SecretKey  string
+	SignInURL  string
+	SignUpURL  string
+	SignOutURL string
+}
+
+const (
+	clerkProdBaseURL = "https://accounts.careme.cooking"
+	clerkDevBaseURL  = "https://bold-salmon-53.accounts.dev"
+)
+
 func Load() (*Config, error) {
 	config := &Config{
 		AI: AIConfig{
@@ -36,6 +49,27 @@ func Load() (*Config, error) {
 		Mocks: MockConfig{
 			Enable: os.Getenv("ENABLE_MOCKS") != "", // strconv
 		},
+	}
+
+	clerkBaseURL := defaultClerkBaseURL(config.Mocks.Enable)
+	signInURL := os.Getenv("CLERK_SIGN_IN_URL")
+	if signInURL == "" {
+		signInURL = clerkBaseURL + "/sign-in"
+	}
+	signUpURL := os.Getenv("CLERK_SIGN_UP_URL")
+	if signUpURL == "" {
+		signUpURL = clerkBaseURL + "/sign-up"
+	}
+	signOutURL := os.Getenv("CLERK_SIGN_OUT_URL")
+	if signOutURL == "" {
+		signOutURL = clerkBaseURL + "/sign-out"
+	}
+
+	config.Clerk = ClerkConfig{
+		SecretKey:  os.Getenv("CLERK_SECRET_KEY"),
+		SignInURL:  signInURL,
+		SignUpURL:  signUpURL,
+		SignOutURL: signOutURL,
 	}
 
 	return config, validate(config)
@@ -51,5 +85,15 @@ func validate(cfg *Config) error {
 	if cfg.AI.APIKey == "" {
 		return fmt.Errorf("AI API  key must be set")
 	}
+	if cfg.Clerk.SecretKey == "" {
+		return fmt.Errorf("clerk secret key must be set")
+	}
 	return nil
+}
+
+func defaultClerkBaseURL(isMock bool) string {
+	if isMock {
+		return clerkDevBaseURL
+	}
+	return clerkProdBaseURL
 }

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -91,6 +91,7 @@
           </ol>
 
           <!-- Signed-out state -->
+          {{if .AuthOffline}}
           <form method="POST" action="/login" class="mt-6">
             <label for="email" class="block text-sm font-medium text-gray-700">
               Enter your email to continue:
@@ -104,6 +105,18 @@
               </button>
             </div>
           </form>
+          {{else}}
+          <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+            <a href="{{.SignInURL}}"
+               class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
+              Sign in
+            </a>
+            <a href="{{.SignUpURL}}"
+               class="inline-flex items-center justify-center rounded-lg border border-brand-200 bg-white px-4 py-2.5 font-semibold text-brand-700 shadow-sm transition hover:bg-brand-50 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
+              Create account
+            </a>
+          </div>
+          {{end}}
           {{end}}
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Move authentication to Clerk's hosted sign-in/up flow while keeping a local/mock path for developer testing.
- Verify Clerk sessions server-side and map Clerk user IDs/emails into the existing `users.Storage` model.

### Description
- Add `Clerk` settings to `config.Config` with sane defaults for prod (`https://accounts.careme.cooking`) and a dev hosted account, and allow overrides via `CLERK_SIGN_IN_URL`, `CLERK_SIGN_UP_URL`, and `CLERK_SIGN_OUT_URL`.
- Introduce an `internal/auth.Manager` that wraps the Clerk Go SDK to verify session tokens, fetch primary email if needed, and provide an offline fallback when `ENABLE_MOCKS=1` and no `CLERK_SECRET_KEY` is configured.
- Wire the auth manager into the server: `cmd/careme/web.go`, `internal/users/server.go`, and `internal/recipes/server.go` now use the auth provider to obtain the current user and decide whether to clear cookies or redirect to hosted pages.
- Update the home template to show hosted `Sign in`/`Create account` buttons when not in offline/mock mode and keep the existing email-based offline login form for mocks.
- Extend `users.Storage` with `FindOrCreateByID` and `ensureEmail` helpers so Clerk user IDs can be persisted and linked to emails, and add corresponding unit tests in `internal/users/storage_test.go`.
- Add `github.com/clerk/clerk-sdk-go/v2` to `go.mod` (server-side verification via Clerk SDK).

### Testing
- Ran code formatting via `gofmt` which completed successfully.
- Ran `go test ./...` which failed due to a missing module checksum / inability to fetch the Clerk SDK in this environment (error: missing go.sum entry for `github.com/clerk/clerk-sdk-go/v2`).
- Attempted to start the server in mock mode with `ENABLE_MOCKS=1 CLERK_SECRET_KEY=sk_test_dummy go run ./cmd/careme -serve -addr :8080` which could not complete because the Clerk SDK module could not be downloaded in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69823a143d508329b753147238e959e3)