### PR TITLE
Use Dockerized Tailwind generation

### DIFF
--- a/tailwind/Dockerfile
+++ b/tailwind/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20.18.1-bookworm-slim
+
+WORKDIR /opt/tailwind
+
+COPY tailwind/package.json tailwind/package-lock.json ./
+RUN npm ci --no-audit --no-fund

--- a/tailwind/generate.sh
+++ b/tailwind/generate.sh
@@ -1,23 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Use a lockfile install and tracked content to ensure deterministic output.
-npm --prefix tailwind ci --no-audit --no-fund
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+image_name="careme-tailwind:latest"
 
-content_files=$(git ls-files "internal/templates/*.html" "internal/templates/**/*.html" | sort -u)
+docker build -f "$repo_root/tailwind/Dockerfile" -t "$image_name" "$repo_root"
+
+content_files=$(git -C "$repo_root" ls-files "internal/templates/*.html" "internal/templates/**/*.html" | sort -u)
 if [ -z "$content_files" ]; then
   echo "No tracked template files found under internal/templates." >&2
   exit 1
 fi
 content_arg=$(printf '%s' "$content_files" | paste -sd, -)
 
-npx --prefix tailwind tailwindcss \
-  -i ./tailwind/input.css \
-  -o ./cmd/careme/static/tailwind.css \
-  --minify \
-  --content "$content_arg"
+docker run --rm \
+  -v "$repo_root":/work \
+  -w /work \
+  -e CONTENT_ARG="$content_arg" \
+  "$image_name" \
+  /bin/sh -c '/opt/tailwind/node_modules/.bin/tailwindcss \
+    -i /work/tailwind/input.css \
+    -o /work/cmd/careme/static/tailwind.css \
+    --minify \
+    --content "$CONTENT_ARG"'
 
 # Normalize output to include a trailing newline for stable diffs.
-if [ -s ./cmd/careme/static/tailwind.css ] && [ "$(tail -c1 ./cmd/careme/static/tailwind.css)" != $'\n' ]; then
-  printf '\n' >> ./cmd/careme/static/tailwind.css
+if [ -s "$repo_root/cmd/careme/static/tailwind.css" ] && [ "$(tail -c1 "$repo_root/cmd/careme/static/tailwind.css")" != $'\n' ]; then
+  printf '\n' >> "$repo_root/cmd/careme/static/tailwind.css"
 fi


### PR DESCRIPTION
### Motivation
- Ensure Tailwind asset generation is deterministic and independent of the developer's local Node/npm installation. 
- Avoid version drift and permission issues when running the Tailwind CLI on different machines.

### Description
- Add `tailwind/Dockerfile` that pins a Node base image and runs `npm ci` to install the Tailwind CLI in `/opt/tailwind`.
- Change `tailwind/generate.sh` to build the Docker image, compute tracked template files with `git -C`, and run the Tailwind CLI inside the container with the repo mounted into `/work`.
- Pass the `--content` argument into the container via the `CONTENT_ARG` environment variable and normalize the output path using a `repo_root` variable.

### Testing
- Ran `go test ./...` and the test run completed successfully.
- Manual verification can be performed with `./tailwind/generate.sh`, which requires Docker to be available locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a831ca0c8329829d4fed72684a34)