### PR TITLE
Register Clerk session listener before load

### DIFF
--- a/internal/templates/clerk_refresh.html
+++ b/internal/templates/clerk_refresh.html
@@ -11,6 +11,17 @@
   (async () => {
     // wait until Clerk is present
     while (!window.Clerk?.load) await new Promise(r => setTimeout(r, 10));
+    // Track whether a session exists before Clerk finishes loading.
+    const hadSessionOnLoad = Boolean(Clerk.session);
+
+    // Clerk calls listeners with a state object; pull out the session field.
+    Clerk.addListener(({ session }) => {
+      // If a session appears after initial load, reload to ensure SSR auth state matches.
+      if (!hadSessionOnLoad && session) {
+        window.location.reload();
+      }
+    });
+
     await Clerk.load();
 
     // Optional: if you want to be extra defensive, force-refresh occasionally


### PR DESCRIPTION
### Motivation
- Ensure server-rendered auth-dependent content stays consistent by reloading when Clerk creates a session during the initial client load.
- Clarify the listener usage so readers understand what `({ session })` means and why we check the session field.

### Description
- Add `const hadSessionOnLoad = Boolean(Clerk.session);` to record whether a session existed before Clerk finished loading.
- Register `Clerk.addListener(({ session }) => { ... })` before calling `await Clerk.load()` so sessions created during `load()` are observed and can trigger a reload.
- Update the listener comment to explain the destructuring `({ session })` and the reload rationale for SSR auth state alignment.

### Testing
- Ran unit tests with `timeout 60s go test ./...` which completed successfully (exit 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ea66ed84832991fb8e72984392ef)