### PR TITLE
Align ingredient quantity and price columns in shopping and recipe views

### DIFF
--- a/internal/templates/recipe.html
+++ b/internal/templates/recipe.html
@@ -60,7 +60,7 @@
                 <ul class="mt-3 space-y-2 text-gray-700">
                   {{range .DisplayIngredients}}
                   <li class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-3 rounded-lg bg-brand-50 px-3 py-2 text-sm">
-                    <span class="min-w-0 font-medium text-brand-700">{{.Name}}</span>
+                    <span class="min-w-0 truncate whitespace-nowrap font-medium text-brand-700">{{.Name}}</span>
                     <span class="whitespace-nowrap text-right text-gray-600">{{.Quantity}}</span>
                     <span class="whitespace-nowrap text-right tabular-nums text-gray-500">{{.Price}}</span>
                   </li>

--- a/internal/templates/recipe.html
+++ b/internal/templates/recipe.html
@@ -59,10 +59,10 @@
                 <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Ingredients</h3>
                 <ul class="mt-3 space-y-2 text-gray-700">
                   {{range .DisplayIngredients}}
-                  <li class="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-brand-50 px-3 py-2 text-sm">
-                    <span class="font-medium text-brand-700">{{.Name}}</span>
-                    <span class="text-gray-600">{{.Quantity}}</span>
-                    <span class="text-gray-500">{{.Price}}</span>
+                  <li class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-3 rounded-lg bg-brand-50 px-3 py-2 text-sm">
+                    <span class="min-w-0 font-medium text-brand-700">{{.Name}}</span>
+                    <span class="whitespace-nowrap text-right text-gray-600">{{.Quantity}}</span>
+                    <span class="whitespace-nowrap text-right tabular-nums text-gray-500">{{.Price}}</span>
                   </li>
                   {{end}}
                 </ul>

--- a/internal/templates/shoppinglist.html
+++ b/internal/templates/shoppinglist.html
@@ -144,10 +144,10 @@
                     <h3 class="text-sm font-semibold uppercase tracking-wide text-ink-500">Ingredients</h3>
                     <ul class="mt-3 space-y-2 text-ink-700">
                       {{range .DisplayIngredients}}
-                      <li class="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-brand-50 px-3 py-2 text-sm">
-                        <span class="font-medium text-brand-700">{{.Name}}</span>
-                        <span class="text-ink-600">{{.Quantity}}</span>
-                        <span class="text-ink-500">{{.Price}}</span>
+                      <li class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-3 rounded-lg bg-brand-50 px-3 py-2 text-sm">
+                        <span class="min-w-0 font-medium text-brand-700">{{.Name}}</span>
+                        <span class="whitespace-nowrap text-right text-ink-600">{{.Quantity}}</span>
+                        <span class="whitespace-nowrap text-right tabular-nums text-ink-500">{{.Price}}</span>
                       </li>
                       {{end}}
                     </ul>

--- a/internal/templates/shoppinglist.html
+++ b/internal/templates/shoppinglist.html
@@ -145,7 +145,7 @@
                     <ul class="mt-3 space-y-2 text-ink-700">
                       {{range .DisplayIngredients}}
                       <li class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-3 rounded-lg bg-brand-50 px-3 py-2 text-sm">
-                        <span class="min-w-0 font-medium text-brand-700">{{.Name}}</span>
+                        <span class="min-w-0 truncate whitespace-nowrap font-medium text-brand-700">{{.Name}}</span>
                         <span class="whitespace-nowrap text-right text-ink-600">{{.Quantity}}</span>
                         <span class="whitespace-nowrap text-right tabular-nums text-ink-500">{{.Price}}</span>
                       </li>


### PR DESCRIPTION
### Motivation
- Fix visual misalignment reported in issue #467 where ingredient quantities and prices did not line up between the shopping list and recipe pages.

### Description
- Replace the previous flex/wrap layout for ingredient rows with a fixed 3-column CSS grid (`name | quantity | price`) in `internal/templates/shoppinglist.html` and `internal/templates/recipe.html`.
- Add `min-w-0` on the name column, and `whitespace-nowrap`, right-alignment, and `tabular-nums` on the quantity/price columns to keep vertical alignment consistent across rows.

### Testing
- Attempted to regenerate Tailwind with `./tailwind/generate.sh`, which failed in this environment due to `docker: command not found`.
- Attempted to run unit tests with `export GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-modcache ENABLE_MOCKS=1 && go test ./...`, which failed in this environment because the Go toolchain download from `proxy.golang.org` returned `Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8269a004c8329a4ed03655e482a54)