### PR TITLE
Add bottom save action on recipe page (hide when already saved)

### DIFF
--- a/internal/recipes/html_test.go
+++ b/internal/recipes/html_test.go
@@ -208,7 +208,9 @@ func TestFormatRecipeHTML_NoFinalizeOrRegenerate(t *testing.T) {
 	p := DefaultParams(&loc, time.Now())
 	p.ConversationID = "convo123"
 	w := httptest.NewRecorder()
-	FormatRecipeHTML(t.Context(), p, list.Recipes[0], true, false, []RecipeThreadEntry{}, feedback.Feedback{}, nil, w)
+	recipe := list.Recipes[0]
+	recipe.OriginHash = "selection-hash"
+	FormatRecipeHTML(t.Context(), p, recipe, true, false, []RecipeThreadEntry{}, feedback.Feedback{}, nil, w)
 	html := w.Body.String()
 
 	isValidHTML(t, html)
@@ -276,8 +278,32 @@ func TestFormatRecipeHTML_NoFinalizeOrRegenerate(t *testing.T) {
 	if !strings.Contains(html, `name="feedback"`) {
 		t.Error("recipe HTML should contain text feedback control")
 	}
+	if !strings.Contains(html, "Save to kitchen") {
+		t.Error("recipe HTML should contain save to kitchen button when recipe can be saved")
+	}
+	if strings.Contains(html, "/dismiss") {
+		t.Error("recipe HTML should not contain dismiss controls")
+	}
 }
 
+func TestFormatRecipeHTML_HidesSaveButtonWhenRecipeAlreadySaved(t *testing.T) {
+	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St"}
+	p := DefaultParams(&loc, time.Now())
+	w := httptest.NewRecorder()
+	recipe := list.Recipes[0]
+	recipe.OriginHash = "selection-hash"
+	recipe.Saved = true
+
+	FormatRecipeHTML(t.Context(), p, recipe, true, false, []RecipeThreadEntry{}, feedback.Feedback{}, nil, w)
+	html := w.Body.String()
+
+	if strings.Contains(html, "Save to kitchen") {
+		t.Error("recipe HTML should hide save button when recipe is already saved")
+	}
+	if !strings.Contains(html, "Saved to kitchen") {
+		t.Error("recipe HTML should show saved status when recipe is already saved")
+	}
+}
 func TestFormatRecipeHTML_HidesQuestionInputWhenSignedOut(t *testing.T) {
 	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St"}
 	p := DefaultParams(&loc, time.Now())

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -614,23 +614,25 @@ func (s *server) handleSaveRecipe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := s.paramsForAction(ctx, selectionHash, currentUser.ID, "")
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to load params for save response", "selection_hash", selectionHash, "error", err)
-		http.Error(w, "failed to save recipe", http.StatusInternalServerError)
-		return
-	}
-
 	var response bytes.Buffer
 	if _, err := fmt.Fprint(&response, `<span class="text-xs font-medium text-action-green-700">Saved to kitchen</span>`); err != nil {
 		slog.ErrorContext(ctx, "failed to build save response", "hash", recipeHash, "error", err)
 		http.Error(w, "failed to write response", http.StatusInternalServerError)
 		return
 	}
-	if err := RenderShoppingFinalizeControlsHTML(selectionHash, len(p.Saved) > 0, &response); err != nil {
-		slog.ErrorContext(ctx, "failed to render finalize controls after save", "selection_hash", selectionHash, "error", err)
-		http.Error(w, "failed to write response", http.StatusInternalServerError)
-		return
+
+	if strings.TrimSpace(r.FormValue("view")) != "recipe" {
+		p, err := s.paramsForAction(ctx, selectionHash, currentUser.ID, "")
+		if err != nil {
+			slog.ErrorContext(ctx, "failed to load params for save response", "selection_hash", selectionHash, "error", err)
+			http.Error(w, "failed to save recipe", http.StatusInternalServerError)
+			return
+		}
+		if err := RenderShoppingFinalizeControlsHTML(selectionHash, len(p.Saved) > 0, &response); err != nil {
+			slog.ErrorContext(ctx, "failed to render finalize controls after save", "selection_hash", selectionHash, "error", err)
+			http.Error(w, "failed to write response", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	setTextContent(w)

--- a/internal/templates/recipe.html
+++ b/internal/templates/recipe.html
@@ -211,6 +211,26 @@
             {{end}}
 
             {{template "recipe_thread" .}}
+
+            {{if and .ServerSignedIn .OriginHash}}
+            <div id="recipe-save-action" class="flex items-center justify-end border-t border-brand-100 pt-4">
+              {{if .Recipe.Saved}}
+              <span class="inline-flex items-center gap-1 text-sm font-medium text-action-green-700">
+                <span aria-hidden="true">✓</span>Saved to kitchen
+              </span>
+              {{else}}
+              <button type="button"
+                      hx-post="/recipe/{{.RecipeHash}}/save"
+                      hx-vals='{"h":"{{.OriginHash}}","view":"recipe"}'
+                      hx-target="#recipe-save-action"
+                      hx-swap="innerHTML"
+                      hx-disabled-elt="this"
+                      class="inline-flex items-center justify-center rounded-lg border-2 border-action-green-500 bg-action-green-50 px-4 py-2 text-sm font-medium text-action-green-700 transition hover:bg-action-green-100 focus:outline-none focus:ring-2 focus:ring-action-green-500 focus:ring-offset-2">
+                Save to kitchen
+              </button>
+              {{end}}
+            </div>
+            {{end}}
           </section>
 
         </div>


### PR DESCRIPTION
### Motivation
- Expose a simple Save action on the single recipe page near the bottom for recipes that originated from a selection so signed-in users can save a recipe without leaving the page. 
- Ensure the page shows a persisted saved state when a recipe is already saved and avoid rendering dismiss controls on the single recipe view.

### Description
- Added a bottom save action in `internal/templates/recipe.html` that is shown when `ServerSignedIn` and `OriginHash` are present, and which renders either a `Save to kitchen` button or a `Saved to kitchen` status when `.Recipe.Saved` is true. 
- The save button posts via HTMX to `/recipe/{{.RecipeHash}}/save` and includes `hx-vals` with the origin selection hash and `view: "recipe"` so the server can tailor the response. 
- Updated `handleSaveRecipe` in `internal/recipes/server.go` to treat `view=recipe` saves as recipe-page requests and avoid returning shopping-list finalize controls for that case, while preserving the previous shopping-list behavior for other saves. 
- Added and updated HTML rendering tests in `internal/recipes/html_test.go` to assert the save button appears for savable recipes and is hidden (showing saved status) when `.Saved` is true, and to assert no dismiss controls are present on the single recipe page.

### Testing
- Ran `gofmt`/`gofmt -w` on modified files successfully to keep formatting clean. 
- Attempted to run `tailwind/generate.sh`, but it failed in this environment due to missing Docker (`docker: command not found`). 
- Attempted `go test ./internal/recipes -run TestFormatRecipeHTML` and `go test ./...`, but the Go toolchain downloads are blocked in this environment (download from `proxy.golang.org` forbidden), so unit tests could not complete here. 
- The new and modified tests are present under `internal/recipes/html_test.go` and should pass in a normal environment where the Go toolchain and `ENABLE_MOCKS=1` are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ab5070e883298088f180c53023ea)