### PR TITLE
Synchronize stub backend in grading tests to fix flake

### DIFF
--- a/internal/ingredients/grading/manager_test.go
+++ b/internal/ingredients/grading/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sync"
 	"testing"
 
 	"careme/internal/ai"
@@ -16,6 +17,7 @@ import (
 const testIngredientGradeCacheVersion = "test-cache-version"
 
 type stubGradeBackend struct {
+	mu    sync.Mutex
 	calls [][]ai.InputIngredient
 }
 
@@ -24,7 +26,9 @@ func (s *stubGradeBackend) CacheVersion() string {
 }
 
 func (s *stubGradeBackend) GradeIngredients(_ context.Context, ingredients []ai.InputIngredient) ([]ai.InputIngredient, error) {
+	s.mu.Lock()
 	s.calls = append(s.calls, append([]ai.InputIngredient(nil), ingredients...))
+	s.mu.Unlock()
 	var out []ai.InputIngredient
 	for _, ingredient := range ingredients {
 		ingredient.Grade = &ai.IngredientGrade{


### PR DESCRIPTION
### Motivation
- `multiGrader` processes batches concurrently and the test stub was appending to a shared slice without synchronization, causing a data race and flaky test outcomes.

### Description
- Add a `sync.Mutex` to `stubGradeBackend` in `internal/ingredients/grading/manager_test.go` and guard the `calls` append with `mu.Lock()`/`mu.Unlock()` to make the stub thread-safe.

### Testing
- Ran `go test ./internal/ingredients/grading` which passed.
- Ran `go test ./internal/ingredients/grading -run TestMultiGraderBatchesUniqueIngredientsInChunksOf30 -count=50` which passed consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc19733c3c8329bd3e9765160d37d8)