### PR TITLE
Add side vegetable variety to menu planner outputs

### DIFF
--- a/cmd/menuplan/main.go
+++ b/cmd/menuplan/main.go
@@ -215,9 +215,9 @@ type mockMenuPlanner struct{}
 
 func (mockMenuPlanner) CreateMenuPlan(context.Context, *locations.Location, []ai.InputIngredient, []string, time.Time, []string, int) (*ai.MenuPlan, error) {
 	return &ai.MenuPlan{Plans: []ai.RecipePlan{
-		{Cuisine: "Korean", AnchorIngredient: "chicken thighs", Technique: "sheet pan"},
-		{Cuisine: "Mexican", AnchorIngredient: "black beans", Technique: "quick simmer"},
-		{Cuisine: "Mediterranean", AnchorIngredient: "seasonal greens", Technique: "grain bowl", Fancy: true},
+		{Cuisine: "Korean", AnchorIngredient: "chicken thighs", Technique: "sheet pan", SideVegetable: "bok choy"},
+		{Cuisine: "Mexican", AnchorIngredient: "black beans", Technique: "quick simmer", SideVegetable: "zucchini"},
+		{Cuisine: "Mediterranean", AnchorIngredient: "seasonal greens", Technique: "grain bowl", SideVegetable: "eggplant", Fancy: true},
 	}}, nil
 }
 
@@ -297,7 +297,11 @@ func writeStoreMenuPlan(w io.Writer, number int, result storeMenuPlan) error {
 		if plan.Fancy {
 			fancy = " (fancier)"
 		}
-		if _, err := fmt.Fprintf(w, "   - %d: %s with %s, %s%s\n", i+1, plan.Cuisine, plan.AnchorIngredient, plan.Technique, fancy); err != nil {
+		sideVegetable := ""
+		if strings.TrimSpace(plan.SideVegetable) != "" {
+			sideVegetable = fmt.Sprintf(", side veg: %s", plan.SideVegetable)
+		}
+		if _, err := fmt.Fprintf(w, "   - %d: %s with %s, %s%s%s\n", i+1, plan.Cuisine, plan.AnchorIngredient, plan.Technique, sideVegetable, fancy); err != nil {
 			return err
 		}
 	}

--- a/cmd/menuplan/main_test.go
+++ b/cmd/menuplan/main_test.go
@@ -88,8 +88,8 @@ func TestWriteMenuPlansHumanReadable(t *testing.T) {
 			},
 			Date: time.Date(2026, time.May, 13, 0, 0, 0, 0, time.UTC),
 			Plan: &ai.MenuPlan{Plans: []ai.RecipePlan{
-				{Cuisine: "Korean", AnchorIngredient: "chicken thighs", Technique: "sheet pan"},
-				{Cuisine: "Thai", AnchorIngredient: "rice noodles", Technique: "stir fry", Fancy: true},
+				{Cuisine: "Korean", AnchorIngredient: "chicken thighs", Technique: "sheet pan", SideVegetable: "broccoli"},
+				{Cuisine: "Thai", AnchorIngredient: "rice noodles", Technique: "stir fry", SideVegetable: "snap peas", Fancy: true},
 			}},
 		},
 		{
@@ -108,8 +108,8 @@ func TestWriteMenuPlansHumanReadable(t *testing.T) {
 		"Address: 1 Market St, WA, 98101",
 		"Date: 2026-05-13",
 		"Plan:",
-		"Korean with chicken thighs, sheet pan",
-		"Thai with rice noodles, stir fry (fancier)",
+		"Korean with chicken thighs, sheet pan, side veg: broccoli",
+		"Thai with rice noodles, stir fry, side veg: snap peas (fancier)",
 		"2. Safeway",
 		"Could not make a menu plan: staples unavailable",
 	} {

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -513,7 +513,6 @@ func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIng
 	if count >= 3 {
 		messages = append(messages, userPromptMessage("Mark one plan fancy."))
 		messages = append(messages, userPromptMessage("Include one less-common cuisine direction."))
-		messages = append(messages, userPromptMessage("Use distinct side vegetables across the plans when possible."))
 	}
 	return messages, nil
 }
@@ -527,7 +526,6 @@ func buildRegenerateMenuPlanMessages(instructions []string, count int) []PromptM
 	if count >= 3 {
 		messages = append(messages, userPromptMessage("Mark one replacement plan fancy."))
 		messages = append(messages, userPromptMessage("Include one less-common cuisine direction."))
-		messages = append(messages, userPromptMessage("Use distinct side vegetables across the plans when possible."))
 	}
 	return messages
 }

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -400,6 +400,7 @@ type RecipePlan struct {
 	Cuisine          string `json:"cuisine"`
 	AnchorIngredient string `json:"anchor_ingredient"`
 	Technique        string `json:"technique"`
+	SideVegetable    string `json:"side_vegetable"`
 	Fancy            bool   `json:"fancy"`
 }
 
@@ -408,6 +409,7 @@ func (p RecipePlan) Instructions() []string {
 		fmt.Sprintf("Cuisine direction for this recipe: %s.", p.Cuisine),
 		fmt.Sprintf("Anchor ingredient direction for this recipe: %s.", p.AnchorIngredient),
 		fmt.Sprintf("Suggested technique for this recipe: %s.", p.Technique),
+		fmt.Sprintf("Side vegetable direction for this recipe: %s.", p.SideVegetable),
 	}
 	if p.Fancy {
 		instructions = append(instructions, "This meal should be fancier, so it can be more expensive, longer, or richer.")
@@ -422,8 +424,8 @@ const menuPlanSystemMessage = `
 You are a menu planner for independent recipe generators.
 
 Return compact planning labels, not recipes. Use short phrases, generally under 5 words, for cuisine, anchor_ingredient, and technique. Set fancy to true only for the richer/splurgier/time intensive option.
-Example plan: {"cuisine":"French Bistro","anchor_ingredient":"chicken thighs","technique":"braise","fancy":false}
-Try and ensure variety across cuisines, anchor ingredients, and techniques.
+Example plan: {"cuisine":"French Bistro","anchor_ingredient":"chicken thighs","technique":"braise","side_vegetable":"green beans","fancy":false}
+Try and ensure variety across cuisines, anchor ingredients, techniques, and side vegetables.
 Prioritize seasonal ingredients, sale value, practical weeknight cooking. 
 Do not write recipe steps, prep instructions, shopping lists, rationale, or prose notes.`
 
@@ -511,6 +513,7 @@ func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIng
 	if count >= 3 {
 		messages = append(messages, userPromptMessage("Mark one plan fancy."))
 		messages = append(messages, userPromptMessage("Include one less-common cuisine direction."))
+		messages = append(messages, userPromptMessage("Use distinct side vegetables across the plans when possible."))
 	}
 	return messages, nil
 }
@@ -524,6 +527,7 @@ func buildRegenerateMenuPlanMessages(instructions []string, count int) []PromptM
 	if count >= 3 {
 		messages = append(messages, userPromptMessage("Mark one replacement plan fancy."))
 		messages = append(messages, userPromptMessage("Include one less-common cuisine direction."))
+		messages = append(messages, userPromptMessage("Use distinct side vegetables across the plans when possible."))
 	}
 	return messages
 }

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -314,6 +314,7 @@ func TestBuildMenuPlanMessagesAddsVarietyRequirementsForThreePlans(t *testing.T)
 	for _, want := range []string{
 		"Mark one plan fancy",
 		"Include one less-common cuisine direction",
+		"Use distinct side vegetables across the plans when possible",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("expected menu plan prompt to contain %q: %s", want, body)
@@ -372,6 +373,7 @@ func TestBuildRegenerateMenuPlanMessagesAddsVarietyRequirementsForThreePlans(t *
 	for _, want := range []string{
 		"Mark one replacement plan fancy",
 		"Include one less-common cuisine direction",
+		"Use distinct side vegetables across the plans when possible",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("expected regenerate menu plan prompt to contain %q: %s", want, body)
@@ -384,16 +386,18 @@ func TestRecipePlanInstructions(t *testing.T) {
 		Cuisine:          "Korean",
 		AnchorIngredient: "tofu",
 		Technique:        "stir-fry",
+		SideVegetable:    "broccoli",
 		Fancy:            true,
 	}
 	got := plan.Instructions()
-	if len(got) != 4 {
-		t.Fatalf("expected four plan instructions, got %v", got)
+	if len(got) != 5 {
+		t.Fatalf("expected five plan instructions, got %v", got)
 	}
 	for _, phrase := range []string{
 		"Cuisine direction for this recipe: Korean.",
 		"Anchor ingredient direction for this recipe: tofu.",
 		"Suggested technique for this recipe: stir-fry.",
+		"Side vegetable direction for this recipe: broccoli.",
 		"fancier",
 	} {
 		if !strings.Contains(strings.Join(got, "\n"), phrase) {

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -314,7 +314,6 @@ func TestBuildMenuPlanMessagesAddsVarietyRequirementsForThreePlans(t *testing.T)
 	for _, want := range []string{
 		"Mark one plan fancy",
 		"Include one less-common cuisine direction",
-		"Use distinct side vegetables across the plans when possible",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("expected menu plan prompt to contain %q: %s", want, body)
@@ -373,7 +372,6 @@ func TestBuildRegenerateMenuPlanMessagesAddsVarietyRequirementsForThreePlans(t *
 	for _, want := range []string{
 		"Mark one replacement plan fancy",
 		"Include one less-common cuisine direction",
-		"Use distinct side vegetables across the plans when possible",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("expected regenerate menu plan prompt to contain %q: %s", want, body)


### PR DESCRIPTION
### Motivation
- Ensure menu plans include a suggested side vegetable and avoid repetitively picking the same side (e.g., asparagus) across all planned meals by making side choices an explicit planning dimension.

### Description
- Added a `side_vegetable` field to `RecipePlan` and included it in the per-recipe `Instructions()` output (`internal/ai/client.go`).
- Updated the menu-plan system prompt and regeneration prompts to request variety across side vegetables in addition to cuisines, anchor ingredients, and techniques (`internal/ai/client.go`).
- Render CLI output to display the side vegetable when present and updated the mock planner and human-readable tests to include side veg examples (`cmd/menuplan/main.go`, `cmd/menuplan/main_test.go`).
- Updated unit tests to assert the new prompt wording, instruction expansion, and CLI formatting (`internal/ai/recipe_test.go`, `cmd/menuplan/main_test.go`).

### Testing
- Ran `go test ./...` and the test suite completed successfully (all tests passed in this environment). 
- Ran `golangci-lint run ./...` which failed in this environment due to the installed `golangci-lint` binary being built with Go 1.24 while the repository targets Go 1.26, so lint could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0caecc4aac8329bd29a797e81eb65f)