### PR TITLE
Sum duplicate shopping-list quantities when unit suffix matches

### DIFF
--- a/internal/recipes/html.go
+++ b/internal/recipes/html.go
@@ -3,9 +3,12 @@ package recipes
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"html/template"
 	"io"
+	"math"
 	"net/http"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -318,14 +321,7 @@ func shoppingListForDisplay(ingredients []ai.Ingredient) []shoppingListGroup {
 
 			continue
 		}
-		qty := strings.TrimSpace(ingredient.Quantity)
-		switch {
-		case qty == "":
-		case existing.Quantity == "":
-			existing.Quantity = qty
-		default:
-			existing.Quantity = existing.Quantity + ", " + qty
-		}
+		existing.Quantity = mergeShoppingQuantities(existing.Quantity, ingredient.Quantity)
 	}
 
 	slices.SortStableFunc(combined, func(a, b *ai.Ingredient) int {
@@ -343,6 +339,60 @@ func shoppingListForDisplay(ingredients []ai.Ingredient) []shoppingListGroup {
 		groups[len(groups)-1].Items = append(groups[len(groups)-1].Items, item)
 	}
 	return groups
+}
+
+var shoppingQtyWithSuffixPattern = regexp.MustCompile(`^\s*(\d+(?:\.\d+)?)\s+(.+?)\s*$`)
+
+func mergeShoppingQuantities(existing string, incoming string) string {
+	existing = strings.TrimSpace(existing)
+	incoming = strings.TrimSpace(incoming)
+	switch {
+	case incoming == "":
+		return existing
+	case existing == "":
+		return incoming
+	}
+
+	existingNumber, existingSuffix, okExisting := parseShoppingQuantity(existing)
+	incomingNumber, incomingSuffix, okIncoming := parseShoppingQuantity(incoming)
+	if okExisting && okIncoming && normalizeShoppingQuantitySuffix(existingSuffix) == normalizeShoppingQuantitySuffix(incomingSuffix) {
+		return formatShoppingQuantity(existingNumber+incomingNumber, existingSuffix)
+	}
+	return existing + ", " + incoming
+}
+
+func parseShoppingQuantity(raw string) (float64, string, bool) {
+	match := shoppingQtyWithSuffixPattern.FindStringSubmatch(beforeFirstComma(raw))
+	if len(match) != 3 {
+		return 0, "", false
+	}
+	value, err := strconv.ParseFloat(match[1], 64)
+	if err != nil {
+		return 0, "", false
+	}
+	suffix := strings.TrimSpace(match[2])
+	if suffix == "" {
+		return 0, "", false
+	}
+	return value, suffix, true
+}
+
+func beforeFirstComma(value string) string {
+	if index := strings.Index(value, ","); index >= 0 {
+		return strings.TrimSpace(value[:index])
+	}
+	return strings.TrimSpace(value)
+}
+
+func normalizeShoppingQuantitySuffix(suffix string) string {
+	return strings.ToLower(strings.Join(strings.Fields(suffix), " "))
+}
+
+func formatShoppingQuantity(value float64, suffix string) string {
+	if math.Abs(value-math.Round(value)) < 1e-9 {
+		return fmt.Sprintf("%d %s", int64(math.Round(value)), suffix)
+	}
+	return fmt.Sprintf("%s %s", strconv.FormatFloat(value, 'f', -1, 64), suffix)
 }
 
 func shoppingAisleHeading(aisle string) string {

--- a/internal/recipes/html_test.go
+++ b/internal/recipes/html_test.go
@@ -676,6 +676,33 @@ func TestFormatShoppingListHTMLForHash_RendersWineOnlyInDetails(t *testing.T) {
 	}
 }
 
+func TestShoppingListForDisplay_SumsMatchingQuantitiesWithSuffix(t *testing.T) {
+	groups := shoppingListForDisplay([]ai.Ingredient{
+		{Name: "Garlic", Quantity: "2 cloves, finely grated or minced"},
+		{Name: "Garlic", Quantity: "2 cloves, minced"},
+		{Name: "Garlic", Quantity: "2 cloves"},
+	})
+	if len(groups) != 1 || len(groups[0].Items) != 1 {
+		t.Fatalf("expected one grouped garlic item, got %+v", groups)
+	}
+	if got, want := groups[0].Items[0].Quantity, "6 cloves"; got != want {
+		t.Fatalf("expected summed quantity %q, got %q", want, got)
+	}
+}
+
+func TestShoppingListForDisplay_KeepsDistinctSuffixesSeparate(t *testing.T) {
+	groups := shoppingListForDisplay([]ai.Ingredient{
+		{Name: "Garlic", Quantity: "2 cloves"},
+		{Name: "Garlic", Quantity: "1 bulb"},
+	})
+	if len(groups) != 1 || len(groups[0].Items) != 1 {
+		t.Fatalf("expected one grouped garlic item, got %+v", groups)
+	}
+	if got, want := groups[0].Items[0].Quantity, "2 cloves, 1 bulb"; got != want {
+		t.Fatalf("expected quantity %q, got %q", want, got)
+	}
+}
+
 func TestFormatRecipeThreadHTML_SortsNewestFirst(t *testing.T) {
 	w := httptest.NewRecorder()
 	now := time.Now()


### PR DESCRIPTION
### Motivation
- Shopping lists should consolidate ingredient amounts when entries refer to the same unit (for example `2 cloves` + `2 cloves` should become `4 cloves`) instead of always concatenating strings.
- Handle common recipe notation where prep notes follow a comma (for example `2 cloves, minced`) by comparing only the numeric+unit portion when deciding whether to sum.

### Description
- Replaced the previous concatenation logic in `shoppingListForDisplay` with `mergeShoppingQuantities` to attempt numeric merging before falling back to appending; changes live in `internal/recipes/html.go`.
- Added quantity parsing and formatting helpers: `parseShoppingQuantity`, `beforeFirstComma`, `normalizeShoppingQuantitySuffix`, and `formatShoppingQuantity`, plus a `regexp` (`shoppingQtyWithSuffixPattern`) to detect `number + suffix` forms.
- When both existing and incoming quantities parse as numbers with the same normalized suffix the code sums their numeric values and renders an integer or decimal as appropriate; otherwise it keeps previous behavior and appends the incoming quantity separated by `, `.
- Added focused tests in `internal/recipes/html_test.go`: `TestShoppingListForDisplay_SumsMatchingQuantitiesWithSuffix` and `TestShoppingListForDisplay_KeepsDistinctSuffixesSeparate` to cover summing behavior and preserving distinct suffixes.

### Testing
- Ran unit tests with `go test ./...` and all packages completed successfully (tests passed).
- New tests for shopping-list quantity merging passed as part of the test run.
- Ran `golangci-lint run ./...` but it failed in this environment because the installed `golangci-lint` binary was built with Go 1.24 while the repo targets Go 1.26; lint should be re-run in CI or a local environment with a compatible `golangci-lint` build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e5c4a5348329acff9f95bdddf88c)