### PR TITLE
Fix menuplan store address line formatting

### DIFF
--- a/cmd/menuplan/main.go
+++ b/cmd/menuplan/main.go
@@ -334,11 +334,18 @@ func storeDetailLines(loc locations.Location) []string {
 	if loc.ID != "" {
 		lines = append(lines, "Store ID: "+loc.ID)
 	}
-	addressParts := compactStrings(loc.Address, loc.State, loc.ZipCode)
-	if len(addressParts) > 0 {
-		lines = append(lines, "Address: "+strings.Join(addressParts, ", "))
+	addressLine := formatAddressLine(loc)
+	if addressLine != "" {
+		lines = append(lines, "Address: "+addressLine)
 	}
 	return lines
+}
+
+
+func formatAddressLine(loc locations.Location) string {
+	stateZip := strings.TrimSpace(strings.Join(compactStrings(loc.State, loc.ZipCode), " "))
+	parts := compactStrings(loc.Address, stateZip)
+	return strings.Join(parts, ", ")
 }
 
 func compactStrings(values ...string) []string {

--- a/cmd/menuplan/main_test.go
+++ b/cmd/menuplan/main_test.go
@@ -104,7 +104,7 @@ func TestWriteMenuPlansHumanReadable(t *testing.T) {
 	for _, want := range []string{
 		"Menu plans for 98101",
 		"1. Kroger - Downtown",
-		"Address: 1 Market St, WA, 98101",
+		"Address: 1 Market St, WA 98101",
 		"Date: 2026-05-13",
 		"Plan:",
 		"Korean with chicken thighs, sheet pan, side veg: broccoli",


### PR DESCRIPTION
### Motivation
- Improve menuplan human-readable store address output to avoid awkward comma separation like `Address: 1 Market St, WA, 98101` as requested in issue #499.

### Description
- Introduced `formatAddressLine(loc locations.Location)` to combine state and ZIP as `State ZIP` and join that with the street address when present instead of comma-separating every component.
- Replaced the inline join in `storeDetailLines` with a call to `formatAddressLine` in `cmd/menuplan/main.go` and updated the test expectation in `cmd/menuplan/main_test.go` to `"Address: 1 Market St, WA 98101"`.

### Testing
- Ran `go test ./...` and all tests passed, including `cmd/menuplan` unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120df809788329a2173c58ee095134)