### PR TITLE
Fix replacement plan count error

### DIFF
--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -134,8 +134,11 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		if err != nil {
 			return nil, fmt.Errorf("failed to plan recipe replacements: %w", err)
 		}
+		if menuPlan == nil {
+			return nil, fmt.Errorf("failed to plan recipe replacements: AI returned no menu plan")
+		}
 		if len(menuPlan.Plans) != len(p.Dismissed) {
-			return nil, fmt.Errorf("failed to plan recipe replacements: %w", err)
+			return nil, fmt.Errorf("failed to plan recipe replacements: planned %d replacements for %d dismissed recipes", len(menuPlan.Plans), len(p.Dismissed))
 		}
 		// does it matter how we associate these?
 		type plannedRegeneration struct {

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -631,6 +631,23 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	}
 }
 
+func TestGenerateRecipes_RegeneratePlanCountMismatchReturnsHelpfulError(t *testing.T) {
+	dismissed := ai.Recipe{Title: "Dismissed Recipe", Description: "Passed on", ResponseID: "resp-123"}
+	aiStub := &captureRegenerateAIClient{
+		menuPlan: &ai.MenuPlan{Plans: []ai.RecipePlan{}, ResponseID: "resp-menu-next"},
+	}
+
+	params := DefaultParams(&locations.Location{ID: "70004001", Name: "Store"}, time.Now())
+	params.Instructions = "make it brighter"
+	params.Dismissed = []ai.Recipe{dismissed}
+	params.PreviousMenuPlanResponseID = "resp-menu-old"
+
+	g := newTestGenerator(t, aiStub, nil, seededStaples(t, params), noopstatuswriter{}, nil)
+	_, err := g.GenerateRecipes(t.Context(), params)
+	require.ErrorContains(t, err, "failed to plan recipe replacements: planned 0 replacements for 1 dismissed recipes")
+	require.NotContains(t, err.Error(), "%!w(<nil>)")
+}
+
 func TestGenerateRecipes_RegenerateBackCompatFallbackUsesFakePlan(t *testing.T) {
 	dismissed := ai.Recipe{Title: "Dismissed Recipe", Description: "Passed on", ResponseID: "resp-123"}
 	newResult := ai.Recipe{Title: "Brand New Dinner", Description: "Fresh idea", ResponseID: "resp-new"}


### PR DESCRIPTION
### Motivation
- Calls that checked the replacement menu plan size used `fmt.Errorf(... %w, err)` after `err` was already nil, which caused logs to show `%!w(<nil>)` instead of a clear message describing the actual mismatch. 
- The goal is to produce a clear, actionable error when the AI menu plan is nil or returns a different number of plans than dismissed recipes.

### Description
- Add a nil guard for the menu plan and return a clear error when `menuPlan == nil` before accessing `menuPlan.Plans` in `GenerateRecipes` (`internal/recipes/generator.go`).
- Replace the previous `%w` wrap on the count-mismatch path with a descriptive error that prints the planned vs dismissed counts, and add a regression test `TestGenerateRecipes_RegeneratePlanCountMismatchReturnsHelpfulError` (`internal/recipes/generator_test.go`).

### Testing
- Ran `go test ./internal/recipes` and the package tests passed.
- Ran `go test ./...` and all repository tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a247d6d4fac83299e3c9437d137d44c)