### PR TITLE
Let menu plans assign recipe-specific user directions and honor user-requested plan counts

### DIFF
--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -35,11 +35,12 @@ func (p MenuPlan) String() string {
 }
 
 type RecipePlan struct {
-	Cuisine          string `json:"cuisine"`
-	AnchorIngredient string `json:"anchor_ingredient"`
-	Technique        string `json:"technique"`
-	SideVegetable    string `json:"side_vegetable"`
-	Fancy            bool   `json:"fancy"`
+	Cuisine            string   `json:"cuisine"`
+	AnchorIngredient   string   `json:"anchor_ingredient"`
+	Technique          string   `json:"technique"`
+	SideVegetable      string   `json:"side_vegetable"`
+	Fancy              bool     `json:"fancy"`
+	RecipeInstructions []string `json:"recipe_instructions"`
 }
 
 func (p RecipePlan) Instructions() []string {
@@ -51,6 +52,11 @@ func (p RecipePlan) Instructions() []string {
 	}
 	if p.Fancy {
 		instructions = append(instructions, "This meal should be fancier, so it can be more expensive, longer, or richer.")
+	}
+	for _, instruction := range p.RecipeInstructions {
+		if trimmed := strings.TrimSpace(instruction); trimmed != "" {
+			instructions = append(instructions, "User direction for this recipe: "+trimmed)
+		}
 	}
 	return instructions
 }
@@ -128,9 +134,10 @@ const menuPlanSystemMessage = `
 You are a menu planner for independent recipe generators.
 
 Return compact planning labels, not recipes. Use short phrases, generally under 5 words, for cuisine, anchor_ingredient, and technique. Set fancy to true only for the richer/splurgier/time intensive option.
-Example plan: {"cuisine":"French Bistro","anchor_ingredient":"chicken thighs","technique":"braise","side_vegetable":"green beans","fancy":false}
+Example plan: {"cuisine":"French Bistro","anchor_ingredient":"chicken thighs","technique":"braise","side_vegetable":"green beans","fancy":false,"recipe_instructions":["Use the user's anise in this recipe."]}
 Try and ensure variety across cuisines, anchor ingredients, techniques, and side vegetables.
-Prioritize seasonal ingredients, sale value, practical weeknight cooking. 
+Prioritize seasonal ingredients, sale value, practical weeknight cooking.
+Assign user directions to recipe_instructions only for the specific recipe plans where they belong. If a user direction applies to every dish, repeat it in every recipe plan's recipe_instructions. If the user mentions having a limited ingredient without asking for it in every dish, assign it to only one fitting recipe.
 Do not write recipe steps, prep instructions, shopping lists, rationale, or prose notes.`
 
 func (c *client) CreateMenuPlan(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
@@ -212,7 +219,7 @@ func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIng
 		return nil, err
 	}
 	messages = append(messages,
-		userPromptMessage(fmt.Sprintf("Build exactly %d distinct recipe plans that fit the available ingredients, seasonality, and price.", count)),
+		userPromptMessage(fmt.Sprintf("Build %d distinct recipe plans by default. If the user's directions clearly ask for a different number of recipes, return that many plans instead. Keep the plan count between 1 and 6. Fit the available ingredients, seasonality, and price.", count)),
 	)
 	cuisines := pickN(cuisineList, 5)
 	messages = append(messages, userPromptMessage("For extra variety, loosely draw from one of these cuisine styles if it fits the ingredients: "+strings.Join(cuisines, ", ")))

--- a/internal/ai/menu_plan_test.go
+++ b/internal/ai/menu_plan_test.go
@@ -60,7 +60,7 @@ func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
 	}
 }
 
-func TestBuildMenuPlanMessagesUsesRequestedCount(t *testing.T) {
+func TestBuildMenuPlanMessagesUsesRequestedCountAsDefault(t *testing.T) {
 	client := NewClient("test-key", "ignored", nil, nil)
 	location := &locationtypes.Location{State: "WA"}
 	messages, err := client.buildMenuPlanMessages(location, nil, nil, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), nil, 2)
@@ -68,8 +68,11 @@ func TestBuildMenuPlanMessagesUsesRequestedCount(t *testing.T) {
 		t.Fatalf("buildMenuPlanMessages returned error: %v", err)
 	}
 	body := mustJSON(t, messages)
-	if !strings.Contains(body, "Build exactly 2 distinct recipe plans") {
-		t.Fatalf("expected requested menu plan count in prompt: %s", body)
+	if !strings.Contains(body, "Build 2 distinct recipe plans by default") {
+		t.Fatalf("expected requested default menu plan count in prompt: %s", body)
+	}
+	if !strings.Contains(body, "If the user's directions clearly ask for a different number of recipes, return that many plans instead") {
+		t.Fatalf("expected prompt to let user directions change the count: %s", body)
 	}
 	if strings.Contains(body, "Mark one plan fancy") {
 		t.Fatalf("did not expect fancy-plan requirement for a two-plan request: %s", body)
@@ -107,6 +110,24 @@ func TestBuildMenuPlanMessagesIncludesCuisineListInspiration(t *testing.T) {
 		if !slices.Contains(cuisineList, cuisine) {
 			t.Fatalf("expected injected cuisine %q to come from cuisineList; prompt cuisines: %v", cuisine, included)
 		}
+	}
+}
+
+func TestRecipePlanInstructionsIncludesPlanSpecificUserDirections(t *testing.T) {
+	plan := RecipePlan{
+		Cuisine:            "French",
+		AnchorIngredient:   "chicken",
+		Technique:          "braise",
+		SideVegetable:      "carrots",
+		RecipeInstructions: []string{"use the anise here", "  "},
+	}
+
+	got := plan.Instructions()
+	if !slices.Contains(got, "User direction for this recipe: use the anise here") {
+		t.Fatalf("expected recipe-specific user direction, got %v", got)
+	}
+	if slices.Contains(got, "User direction for this recipe: ") {
+		t.Fatalf("expected blank recipe-specific directions to be skipped, got %v", got)
 	}
 }
 
@@ -152,7 +173,7 @@ func TestCreateMenuPlanRecordsPrompt(t *testing.T) {
 		t.Fatalf("unexpected instructions: %q", recorder.record.Instructions)
 	}
 	body := mustJSON(t, recorder.record.Input)
-	if !strings.Contains(body, "Build exactly 2 distinct recipe plans") || !strings.Contains(body, "make it vegetarian") {
+	if !strings.Contains(body, "Build 2 distinct recipe plans by default") || !strings.Contains(body, "make it vegetarian") {
 		t.Fatalf("unexpected recorded menu prompt: %s", body)
 	}
 }

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -213,10 +213,10 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 	g.writeStatus(ctx, hash, status.Ingredients(ingredients, ogCount))
 	mutable.Shuffle(ingredients)
 
-	instructions := []string{p.Directive, p.Instructions}
+	menuPlanInstructions := []string{p.Directive, p.Instructions}
+	recipeBaseInstructions := []string{p.Directive}
 
-	// 3 is arbitrary let user decide?
-	menuPlan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, instructions, p.Date, p.LastRecipes, 3)
+	menuPlan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, 3)
 	if err != nil {
 		return nil, fmt.Errorf("failed to plan recipe variety: %w", err)
 	}
@@ -225,7 +225,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 	results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 		ctx, span := tracer.Start(ctx, "recipes.generate.single")
 		defer span.End()
-		recipeInstructions := append(slices.Clone(instructions), plan.Instructions()...)
+		recipeInstructions := append(slices.Clone(recipeBaseInstructions), plan.Instructions()...)
 		recipe, err := g.aiClient.GenerateRecipe(ctx, p.Location, ingredients, recipeInstructions, p.Date, p.LastRecipes)
 		if err != nil {
 			return nil, err

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -38,11 +38,13 @@ type captureRegenerateAIClient struct {
 }
 
 type captureGenerateAIClient struct {
-	shoppingList *ai.ShoppingList
-	ingredients  []ai.InputIngredient
-	instructions [][]string
-	lastRecipes  []string
-	mu           sync.Mutex
+	shoppingList         *ai.ShoppingList
+	menuPlan             *ai.MenuPlan
+	ingredients          []ai.InputIngredient
+	instructions         [][]string
+	generateInstructions [][]string
+	lastRecipes          []string
+	mu                   sync.Mutex
 }
 
 type sequenceAIClient struct {
@@ -208,6 +210,9 @@ func (c *captureGenerateAIClient) CreateMenuPlan(ctx context.Context, location *
 	c.ingredients = append([]ai.InputIngredient(nil), ingredients...)
 	c.instructions = append(c.instructions, append([]string(nil), instructions...))
 	c.lastRecipes = append([]string(nil), lastRecipes...)
+	if c.menuPlan != nil {
+		return c.menuPlan, nil
+	}
 	if c.shoppingList != nil {
 		return menuPlanForRecipes(c.shoppingList.Recipes), nil
 	}
@@ -222,6 +227,7 @@ func (c *captureGenerateAIClient) GenerateRecipe(ctx context.Context, location *
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
 	if c.shoppingList == nil {
 		return &ai.Recipe{}, nil
 	}
@@ -703,6 +709,49 @@ func TestGenerateRecipes_RegenerateWithOnlySavedRecipesPreservesSavedRecipes(t *
 	if got == nil || len(got.Recipes) != 1 || got.Recipes[0].ComputeHash() != saved.ComputeHash() {
 		t.Fatalf("expected saved recipe to be preserved, got %+v", got)
 	}
+}
+
+func TestGenerateRecipes_UsesMenuPlanRecipeInstructionsInsteadOfSendingUserDirectionsToEveryRecipe(t *testing.T) {
+	params := DefaultParams(&locations.Location{ID: "70004001", Name: "Store"}, time.Now())
+	params.Directive = "Use sale ingredients."
+	params.Instructions = "I have some anise."
+
+	aniseRecipe := ai.Recipe{Title: "Anise Chicken", Description: "Uses the anise", ResponseID: "resp-anise"}
+	plainRecipe := ai.Recipe{Title: "Plain Pasta", Description: "No anise", ResponseID: "resp-plain"}
+	aiStub := &captureGenerateAIClient{
+		shoppingList: &ai.ShoppingList{Recipes: []ai.Recipe{aniseRecipe, plainRecipe}},
+		menuPlan: &ai.MenuPlan{Plans: []ai.RecipePlan{
+			{Cuisine: "test", AnchorIngredient: aniseRecipe.Title, Technique: "test", RecipeInstructions: []string{"Use the user's anise in this recipe."}},
+			{Cuisine: "test", AnchorIngredient: plainRecipe.Title, Technique: "test"},
+		}},
+	}
+	g := newTestGenerator(t, aiStub, nil, seededStaples(t, params), noopstatuswriter{}, nil)
+
+	got, err := g.GenerateRecipes(t.Context(), params)
+	require.NoError(t, err)
+	require.Len(t, got.Recipes, 2)
+	require.Len(t, aiStub.generateInstructions, 2)
+
+	for _, instructions := range aiStub.generateInstructions {
+		assert.NotContains(t, instructions, "I have some anise.")
+		assert.Contains(t, instructions, "Use sale ingredients.")
+	}
+
+	aniseInstructions := instructionsForAnchor(t, aiStub.generateInstructions, aniseRecipe.Title)
+	plainInstructions := instructionsForAnchor(t, aiStub.generateInstructions, plainRecipe.Title)
+	assert.Contains(t, aniseInstructions, "User direction for this recipe: Use the user's anise in this recipe.")
+	assert.NotContains(t, plainInstructions, "User direction for this recipe: Use the user's anise in this recipe.")
+}
+
+func instructionsForAnchor(t *testing.T, calls [][]string, title string) []string {
+	t.Helper()
+	for _, instructions := range calls {
+		if recipeInstructionsContainAnchor(instructions, title) {
+			return instructions
+		}
+	}
+	t.Fatalf("missing generate call for %q in %v", title, calls)
+	return nil
 }
 
 func TestGenerateRecipes_CritiquesGeneratedRecipes(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Users expect limited ingredients (e.g., “I have some anise”) to be assigned to one fitting recipe rather than being blindly applied to every dish. 
- The menu planner should be allowed to change the number of recipes when the user explicitly requests a different count.

### Description
- Added `RecipeInstructions []string` to `ai.RecipePlan` and include them in `RecipePlan.Instructions()` so per-plan user directions are rendered as recipe-scoped prompts. 
- Updated the menu planning system prompt to instruct the planner to assign limited user directions to specific plans, to repeat directions in every plan only when the user asks, and to treat the requested plan count as a default that the planner may override when user directions demand a different number. 
- Changed recipe generation flow in `generatorService.GenerateRecipes` to send `menuPlanInstructions` (global directive + user instructions) to the menu planner and to send only `recipeBaseInstructions` plus the selected plan's `Instructions()` to each `GenerateRecipe` call so raw user directions are not duplicated across all recipes. 
- Extended and adjusted test fixtures and mocks (`captureGenerateAIClient` and related tests) and added tests covering prompt wording and routing of plan-specific user directions.

### Testing
- Ran `go test ./internal/ai ./internal/recipes ./cmd/menuplan` and the targeted suites passed. 
- Ran `go test ./...` and `go vet ./...` and they passed in the CI-like environment used for verification. 
- `golangci-lint run ./...` was not executed successfully due to the local `golangci-lint` binary being built with Go 1.24 while the repository targets Go 1.26, so linting was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a247deed5d08329ab2fbaf93bca4ce1)