### PR TITLE
Drive recipes off menuplan response id

### DIFF
--- a/docs/recipe-generation-walkthrough.md
+++ b/docs/recipe-generation-walkthrough.md
@@ -7,8 +7,8 @@ This document covers the first-time generation path inside `generatorService.Gen
 ```mermaid
 flowchart TD
     subgraph Legend["Model color"]
-        MiniLegend["gpt-5-mini<br/>Grading + menu planning"]
-        GPT5Legend["gpt-5.5<br/>Recipe generation + retry"]
+        MiniLegend["gpt-5-mini<br/>Grading"]
+        GPT5Legend["gpt-5.5<br/>Menu planning + recipe generation + retry"]
         GeminiLegend["Gemini<br/>Recipe critique"]
     end
 
@@ -85,7 +85,7 @@ The model boundary in this section is ingredient grading. Fetching staples is st
 
 ## Menu Plan And Recipe Fan-Out
 
-After grading, `GenerateRecipes` shuffles the ingredient list and calls the menu-planning model through `CreateMenuPlan` for exactly three plans. The menu plan request includes the location, filtered ingredients, user directive, user instructions, recipe date, and recently cooked recipe titles. Menu planning uses `gpt-5-mini`.
+After grading, `GenerateRecipes` shuffles the ingredient list and calls the menu-planning model through `CreateMenuPlan` for exactly three plans. The menu plan request includes the location, filtered ingredients, user directive, user instructions, recipe date, and recently cooked recipe titles. Menu planning uses `gpt-5.5`.
 
 The returned `menuPlan.Plans` are processed with `parallelism.MapWithErrors`. Each plan becomes one worker and makes its own `gpt-5.5` recipe model call:
 

--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -214,11 +214,10 @@ func responseToMenuPlan(ctx context.Context, category, model string, resp *respo
 func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIngredients []InputIngredient,
 	instructions []string, date time.Time, lastRecipes []string, count int,
 ) ([]PromptMessage, error) {
-	messages, err := c.buildSharedContextMessages(location, saleIngredients, date, lastRecipes)
+	messages, err := c.buildSharedContextMessages(location, saleIngredients, instructions, date, lastRecipes)
 	if err != nil {
 		return nil, err
 	}
-	messages = append(messages, cleanInstructionMessages(instructions)...)
 	messages = append(messages,
 		userPromptMessage(fmt.Sprintf("Build %d distinct recipe plans by default. If the user's directions clearly ask for a different number of recipes, return that many plans instead. Keep the plan count between 1 and 6. Fit the available ingredients, seasonality, and price.", count)),
 	)

--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -214,7 +214,7 @@ func responseToMenuPlan(ctx context.Context, category, model string, resp *respo
 func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIngredients []InputIngredient,
 	instructions []string, date time.Time, lastRecipes []string, count int,
 ) ([]PromptMessage, error) {
-	messages, err := c.buildRecipeContextMessages(location, saleIngredients, instructions, date, lastRecipes)
+	messages, err := c.buildSharedContextMessages(location, saleIngredients, instructions, date, lastRecipes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -214,10 +214,11 @@ func responseToMenuPlan(ctx context.Context, category, model string, resp *respo
 func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIngredients []InputIngredient,
 	instructions []string, date time.Time, lastRecipes []string, count int,
 ) ([]PromptMessage, error) {
-	messages, err := c.buildSharedContextMessages(location, saleIngredients, instructions, date, lastRecipes)
+	messages, err := c.buildSharedContextMessages(location, saleIngredients, date, lastRecipes)
 	if err != nil {
 		return nil, err
 	}
+	messages = append(messages, cleanInstructionMessages(instructions)...)
 	messages = append(messages,
 		userPromptMessage(fmt.Sprintf("Build %d distinct recipe plans by default. If the user's directions clearly ask for a different number of recipes, return that many plans instead. Keep the plan count between 1 and 6. Fit the available ingredients, seasonality, and price.", count)),
 	)

--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -17,7 +17,7 @@ import (
 	"github.com/samber/lo"
 )
 
-const recipePlanModel = openai.ChatModelGPT5Mini // need to play witht this
+const recipePlanModel = defaultRecipeModel
 
 type MenuPlan struct {
 	Plans      []RecipePlan `json:"plans"`
@@ -35,11 +35,12 @@ func (p MenuPlan) String() string {
 }
 
 type RecipePlan struct {
-	Cuisine            string   `json:"cuisine"`
-	AnchorIngredient   string   `json:"anchor_ingredient"`
-	Technique          string   `json:"technique"`
-	SideVegetable      string   `json:"side_vegetable"`
-	Fancy              bool     `json:"fancy"`
+	Cuisine          string `json:"cuisine"`
+	AnchorIngredient string `json:"anchor_ingredient"`
+	Technique        string `json:"technique"`
+	SideVegetable    string `json:"side_vegetable"`
+	Fancy            bool   `json:"fancy"`
+	// so generic this is directive, user instructions, servings, time? Split it up?
 	RecipeInstructions []string `json:"recipe_instructions"`
 }
 
@@ -249,7 +250,7 @@ func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIng
 func buildRegenerateMenuPlanMessages(instructions []string, count int) []PromptMessage {
 	messages := cleanInstructionMessages(instructions)
 	messages = append(messages,
-		userPromptMessage(fmt.Sprintf("Pick exactly %d replacement plans. Avoid passed-on recipe titles and close variants. Fit the user's feedback.", count)),
+		userPromptMessage(fmt.Sprintf("Build %d replacement recipe plan(s) by default. If the user's directions clearly ask for a different number of recipes, return that many plans instead. Keep the plan count between 1 and 6. Avoid passed-on recipe titles and close variants. Fit the user's feedback.", count)),
 	)
 	// ideally do this if they dismissed fancy.
 	if count >= 3 {

--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -212,6 +212,23 @@ func responseToMenuPlan(ctx context.Context, category, model string, resp *respo
 	return &plan, nil
 }
 
+func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time) ([]PromptMessage, error) {
+	var messages []PromptMessage
+	// constants we might make variable later
+	messages = append(messages, userPromptMessage("Prioritize ingredients that are in season for the current date and user's state location "+date.Format("January 2nd")+" in "+location.State+"."))
+
+	// todo reuse context via response id?
+	ingredientsMessage := fmt.Sprintf("%d ingredients available in TSV format with header.\n", len(saleIngredients))
+	var buf strings.Builder
+	if err := InputIngredientsToTSV(saleIngredients, &buf); err != nil {
+		return nil, fmt.Errorf("failed to convert ingredients to TSV: %w", err)
+	}
+	ingredientsMessage += buf.String()
+	messages = append(messages, userPromptMessage(ingredientsMessage))
+
+	return messages, nil
+}
+
 func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIngredients []InputIngredient,
 	instructions []string, date time.Time, lastRecipes []string, count int,
 ) ([]PromptMessage, error) {

--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -212,12 +212,12 @@ func responseToMenuPlan(ctx context.Context, category, model string, resp *respo
 	return &plan, nil
 }
 
-func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time) ([]PromptMessage, error) {
+func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIngredients []InputIngredient,
+	instructions []string, date time.Time, lastRecipes []string, count int,
+) ([]PromptMessage, error) {
 	var messages []PromptMessage
-	// constants we might make variable later
 	messages = append(messages, userPromptMessage("Prioritize ingredients that are in season for the current date and user's state location "+date.Format("January 2nd")+" in "+location.State+"."))
 
-	// todo reuse context via response id?
 	ingredientsMessage := fmt.Sprintf("%d ingredients available in TSV format with header.\n", len(saleIngredients))
 	var buf strings.Builder
 	if err := InputIngredientsToTSV(saleIngredients, &buf); err != nil {
@@ -226,27 +226,15 @@ func (c *client) buildSharedContextMessages(location *locationtypes.Location, sa
 	ingredientsMessage += buf.String()
 	messages = append(messages, userPromptMessage(ingredientsMessage))
 
-	return messages, nil
-}
-
-func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIngredients []InputIngredient,
-	instructions []string, date time.Time, lastRecipes []string, count int,
-) ([]PromptMessage, error) {
-	messages, err := c.buildSharedContextMessages(location, saleIngredients, date)
-	if err != nil {
-		return nil, err
-	}
-
 	messages = append(messages,
 		userPromptMessage(fmt.Sprintf("Build %d distinct recipe plans by default. If the user's directions clearly ask for a different number of recipes, return that many plans instead. Keep the plan count between 1 and 6. Fit the available ingredients, seasonality, and price.", count)),
 	)
-	cuisines := pickN(cuisineList, 5)
+	cuisines := pickN(cuisineList, 6)
 	messages = append(messages, userPromptMessage("For extra variety, loosely draw from one of these cuisine styles if it fits the ingredients: "+strings.Join(cuisines, ", ")))
 	// messages = append(messages, userPromptMessage("but don't overlook local cuisine"))
-	if count >= 3 {
-		messages = append(messages, userPromptMessage("Mark one plan fancy."))
-		// messages = append(messages, userPromptMessage("Include one less-common cuisine direction."))
-	}
+
+	// this fails on regen
+	messages = append(messages, userPromptMessage("If doing more than 3 plans mark one plan fancy."))
 
 	if len(lastRecipes) > 0 {
 		var prevRecipesMsg strings.Builder
@@ -269,10 +257,8 @@ func buildRegenerateMenuPlanMessages(instructions []string, count int) []PromptM
 	messages = append(messages,
 		userPromptMessage(fmt.Sprintf("Build %d replacement recipe plan(s) by default. If the user's directions clearly ask for a different number of recipes, return that many plans instead. Keep the plan count between 1 and 6. Avoid passed-on recipe titles and close variants. Fit the user's feedback.", count)),
 	)
-	// ideally do this if they dismissed fancy.
-	if count >= 3 {
-		messages = append(messages, userPromptMessage("Mark one replacement plan fancy."))
-		// messages = append(messages, userPromptMessage("Include one less-common cuisine direction."))
-	}
+	messages = append(messages, userPromptMessage("If fancy plan was dismissed make one of the new ones fancy"))
+	// messages = append(messages, userPromptMessage("Include one less-common cuisine direction."))
+
 	return messages
 }

--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -214,10 +214,11 @@ func responseToMenuPlan(ctx context.Context, category, model string, resp *respo
 func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIngredients []InputIngredient,
 	instructions []string, date time.Time, lastRecipes []string, count int,
 ) ([]PromptMessage, error) {
-	messages, err := c.buildSharedContextMessages(location, saleIngredients, instructions, date, lastRecipes)
+	messages, err := c.buildSharedContextMessages(location, saleIngredients, date)
 	if err != nil {
 		return nil, err
 	}
+
 	messages = append(messages,
 		userPromptMessage(fmt.Sprintf("Build %d distinct recipe plans by default. If the user's directions clearly ask for a different number of recipes, return that many plans instead. Keep the plan count between 1 and 6. Fit the available ingredients, seasonality, and price.", count)),
 	)
@@ -228,6 +229,20 @@ func (c *client) buildMenuPlanMessages(location *locationtypes.Location, saleIng
 		messages = append(messages, userPromptMessage("Mark one plan fancy."))
 		// messages = append(messages, userPromptMessage("Include one less-common cuisine direction."))
 	}
+
+	if len(lastRecipes) > 0 {
+		var prevRecipesMsg strings.Builder
+		prevRecipesMsg.WriteString("Avoid recipes similar to these previously cooked:\n")
+		for _, recipe := range lastRecipes {
+			fmt.Fprintf(&prevRecipesMsg, "%s\n", recipe)
+		}
+		messages = append(messages, userPromptMessage(prevRecipesMsg.String()))
+	}
+
+	messages = append(messages, userPromptMessage("Default: cooking methods: oven, stove, grill, slow cooker"))
+	messages = append(messages, userPromptMessage("Default: total recipe time, including prep and all timed steps, should stay under 1 hour"))
+	messages = append(messages, userPromptMessage("Default: each recipe should serve 2 people."))
+	messages = append(messages, cleanInstructionMessages(instructions)...)
 	return messages, nil
 }
 

--- a/internal/ai/menu_plan_test.go
+++ b/internal/ai/menu_plan_test.go
@@ -25,7 +25,7 @@ func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
 	lastRecipes := []string{"Lemon chicken pasta"}
 	date := time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC)
 
-	contextMessages, err := client.buildSharedContextMessages(location, ingredients, date, lastRecipes)
+	contextMessages, err := client.buildSharedContextMessages(location, ingredients, date)
 	if err != nil {
 		t.Fatalf("buildSharedContextMessages returned error: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
 	}
 }
 
-func TestBuildMenuPlanMessagesOmitsRecipeOnlyDefaults(t *testing.T) {
+func TestBuildMenuPlanMessagesIncludesRecipeParentDefaults(t *testing.T) {
 	client := NewClient("test-key", "ignored", nil, nil)
 	location := &locationtypes.Location{State: "WA"}
 	messages, err := client.buildMenuPlanMessages(location, nil, nil, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), nil, 3)
@@ -56,12 +56,12 @@ func TestBuildMenuPlanMessagesOmitsRecipeOnlyDefaults(t *testing.T) {
 		t.Fatalf("buildMenuPlanMessages returned error: %v", err)
 	}
 	body := mustJSON(t, messages)
-	for _, excluded := range []string{
+	for _, included := range []string{
 		"Default: each recipe should serve 2 people.",
 		"Default: total recipe time, including prep and all timed steps, should stay under 1 hour",
 	} {
-		if strings.Contains(body, excluded) {
-			t.Fatalf("menu planning should not receive recipe-only default %q: %s", excluded, body)
+		if !strings.Contains(body, included) {
+			t.Fatalf("menu planning should include recipe parent default %q: %s", included, body)
 		}
 	}
 }
@@ -187,8 +187,14 @@ func TestCreateMenuPlanRecordsPrompt(t *testing.T) {
 func TestBuildRegenerateMenuPlanMessagesUsesReplacementPrompt(t *testing.T) {
 	messages := buildRegenerateMenuPlanMessages([]string{"make it vegetarian", "Passed on roast chicken"}, 1)
 	body := mustJSON(t, messages)
-	if !strings.Contains(body, "Pick exactly 1 replacement plans") {
-		t.Fatalf("expected replacement count in prompt: %s", body)
+	for _, want := range []string{
+		"Build 1 replacement recipe plan(s) by default",
+		"If the user's directions clearly ask for a different number of recipes, return that many plans instead",
+		"Keep the plan count between 1 and 6",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected replacement prompt to contain %q: %s", want, body)
+		}
 	}
 	if !strings.Contains(body, "make it vegetarian") || !strings.Contains(body, "Passed on roast chicken") {
 		t.Fatalf("expected feedback instructions in prompt: %s", body)
@@ -251,7 +257,7 @@ func TestRegenerateMenuPlanRecordsPrompt(t *testing.T) {
 		t.Fatalf("unexpected prompt record: %#v", recorder.record)
 	}
 	body := mustJSON(t, recorder.record.Input)
-	if !strings.Contains(body, "Pick exactly 1 replacement plans") || !strings.Contains(body, "less spicy") {
+	if !strings.Contains(body, "Build 1 replacement recipe plan(s) by default") || !strings.Contains(body, "less spicy") {
 		t.Fatalf("unexpected recorded regenerate prompt: %s", body)
 	}
 }

--- a/internal/ai/menu_plan_test.go
+++ b/internal/ai/menu_plan_test.go
@@ -25,7 +25,7 @@ func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
 	lastRecipes := []string{"Lemon chicken pasta"}
 	date := time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC)
 
-	contextMessages, err := client.buildSharedContextMessages(location, ingredients, date, lastRecipes)
+	contextMessages, err := client.buildSharedContextMessages(location, ingredients, instructions, date, lastRecipes)
 	if err != nil {
 		t.Fatalf("buildSharedContextMessages returned error: %v", err)
 	}

--- a/internal/ai/menu_plan_test.go
+++ b/internal/ai/menu_plan_test.go
@@ -25,9 +25,9 @@ func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
 	lastRecipes := []string{"Lemon chicken pasta"}
 	date := time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC)
 
-	contextMessages, err := client.buildRecipeContextMessages(location, ingredients, instructions, date, lastRecipes)
+	contextMessages, err := client.buildSharedContextMessages(location, ingredients, instructions, date, lastRecipes)
 	if err != nil {
-		t.Fatalf("buildRecipeContextMessages returned error: %v", err)
+		t.Fatalf("buildSharedContextMessages returned error: %v", err)
 	}
 	menuMessages, err := client.buildMenuPlanMessages(location, ingredients, instructions, date, lastRecipes, 3)
 	if err != nil {
@@ -44,6 +44,24 @@ func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
 	for _, message := range contextMessages {
 		if message.Role != "user" {
 			t.Fatalf("expected only user prompt messages, got %#v", contextMessages)
+		}
+	}
+}
+
+func TestBuildMenuPlanMessagesOmitsRecipeOnlyDefaults(t *testing.T) {
+	client := NewClient("test-key", "ignored", nil, nil)
+	location := &locationtypes.Location{State: "WA"}
+	messages, err := client.buildMenuPlanMessages(location, nil, nil, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), nil, 3)
+	if err != nil {
+		t.Fatalf("buildMenuPlanMessages returned error: %v", err)
+	}
+	body := mustJSON(t, messages)
+	for _, excluded := range []string{
+		"Default: each recipe should serve 2 people.",
+		"Default: total recipe time, including prep and all timed steps, should stay under 1 hour",
+	} {
+		if strings.Contains(body, excluded) {
+			t.Fatalf("menu planning should not receive recipe-only default %q: %s", excluded, body)
 		}
 	}
 }

--- a/internal/ai/menu_plan_test.go
+++ b/internal/ai/menu_plan_test.go
@@ -25,7 +25,7 @@ func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
 	lastRecipes := []string{"Lemon chicken pasta"}
 	date := time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC)
 
-	contextMessages, err := client.buildSharedContextMessages(location, ingredients, instructions, date, lastRecipes)
+	contextMessages, err := client.buildSharedContextMessages(location, ingredients, date, lastRecipes)
 	if err != nil {
 		t.Fatalf("buildSharedContextMessages returned error: %v", err)
 	}

--- a/internal/ai/menu_plan_test.go
+++ b/internal/ai/menu_plan_test.go
@@ -12,42 +12,6 @@ import (
 	locationtypes "careme/internal/locations/types"
 )
 
-func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
-	client := NewClient("test-key", "ignored", nil, nil)
-	location := &locationtypes.Location{State: "WA"}
-	ingredients := []InputIngredient{
-		{ProductID: "chicken-1", Description: "Chicken thighs", Size: "2 lb", PriceRegular: new(float32)},
-		{ProductID: "beans-1", Description: "Green beans", Size: "12 oz", PriceRegular: new(float32)},
-	}
-	*ingredients[0].PriceRegular = 8.99
-	*ingredients[1].PriceRegular = 2.99
-	instructions := []string{"make it high protein"}
-	lastRecipes := []string{"Lemon chicken pasta"}
-	date := time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC)
-
-	contextMessages, err := client.buildSharedContextMessages(location, ingredients, date)
-	if err != nil {
-		t.Fatalf("buildSharedContextMessages returned error: %v", err)
-	}
-	menuMessages, err := client.buildMenuPlanMessages(location, ingredients, instructions, date, lastRecipes, 3)
-	if err != nil {
-		t.Fatalf("buildMenuPlanMessages returned error: %v", err)
-	}
-
-	prefixLen := len(contextMessages)
-	if prefixLen == 0 {
-		t.Fatal("expected shared context prefix")
-	}
-	if got, want := mustJSON(t, menuMessages[:prefixLen]), mustJSON(t, contextMessages); got != want {
-		t.Fatalf("menu planning should share prompt prefix with recipe context:\ngot  %s\nwant %s", got, want)
-	}
-	for _, message := range contextMessages {
-		if message.Role != "user" {
-			t.Fatalf("expected only user prompt messages, got %#v", contextMessages)
-		}
-	}
-}
-
 func TestBuildMenuPlanMessagesIncludesRecipeParentDefaults(t *testing.T) {
 	client := NewClient("test-key", "ignored", nil, nil)
 	location := &locationtypes.Location{State: "WA"}
@@ -140,12 +104,13 @@ func TestRecipePlanInstructionsIncludesPlanSpecificUserDirections(t *testing.T) 
 func TestBuildMenuPlanMessagesAddsFancyRequirementForThreePlans(t *testing.T) {
 	client := NewClient("test-key", "ignored", nil, nil)
 	location := &locationtypes.Location{State: "WA"}
-	messages, err := client.buildMenuPlanMessages(location, nil, nil, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), nil, 3)
+	date := time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC)
+	messages, err := client.buildMenuPlanMessages(location, nil, nil, date, nil, 3)
 	if err != nil {
 		t.Fatalf("buildMenuPlanMessages returned error: %v", err)
 	}
 	body := mustJSON(t, messages)
-	if !strings.Contains(body, "Mark one plan fancy") {
+	if !strings.Contains(body, "If doing more than 3 plans mark one plan fancy.") {
 		t.Fatalf("expected menu plan prompt to contain fancy requirement: %s", body)
 	}
 }
@@ -204,7 +169,7 @@ func TestBuildRegenerateMenuPlanMessagesUsesReplacementPrompt(t *testing.T) {
 func TestBuildRegenerateMenuPlanMessagesAddsFancyRequirementForThreePlans(t *testing.T) {
 	messages := buildRegenerateMenuPlanMessages(nil, 3)
 	body := mustJSON(t, messages)
-	if !strings.Contains(body, "Mark one replacement plan fancy") {
+	if !strings.Contains(body, "make one of the new ones fancy") {
 		t.Fatalf("expected regenerate menu plan prompt to contain fancy requirement: %s", body)
 	}
 }

--- a/internal/ai/menu_plan_test.go
+++ b/internal/ai/menu_plan_test.go
@@ -33,29 +33,17 @@ func TestMenuPlanAndRecipeMessagesShareCachePrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildMenuPlanMessages returned error: %v", err)
 	}
-	recipeInstructions := append(slices.Clone(instructions), RecipePlan{
-		Cuisine:          "Korean",
-		AnchorIngredient: "chicken thighs",
-		Technique:        "stir-fry",
-	}.Instructions()...)
-	recipeMessages, err := client.buildRecipeMessages(location, ingredients, recipeInstructions, date, lastRecipes)
-	if err != nil {
-		t.Fatalf("buildRecipeMessages returned error: %v", err)
-	}
 
 	prefixLen := len(contextMessages)
 	if prefixLen == 0 {
 		t.Fatal("expected shared context prefix")
 	}
-	if got, want := mustJSON(t, menuMessages[:prefixLen]), mustJSON(t, recipeMessages[:prefixLen]); got != want {
-		t.Fatalf("menu planning and recipe generation should share prompt prefix:\ngot  %s\nwant %s", got, want)
+	if got, want := mustJSON(t, menuMessages[:prefixLen]), mustJSON(t, contextMessages); got != want {
+		t.Fatalf("menu planning should share prompt prefix with recipe context:\ngot  %s\nwant %s", got, want)
 	}
-	if got, want := mustJSON(t, contextMessages), mustJSON(t, recipeMessages[:prefixLen]); got != want {
-		t.Fatalf("recipe generation prefix should match shared context:\ngot  %s\nwant %s", got, want)
-	}
-	for _, message := range recipeMessages {
+	for _, message := range contextMessages {
 		if message.Role != "user" {
-			t.Fatalf("expected only user prompt messages, got %#v", recipeMessages)
+			t.Fatalf("expected only user prompt messages, got %#v", contextMessages)
 		}
 	}
 }

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -169,10 +169,11 @@ func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtyp
 	if err != nil {
 		return nil, fmt.Errorf("failed to build recipe context messages: %w", err)
 	}
+	promptMessages = append(promptMessages, userPromptMessage(prepareRecipeContextInstruction))
 
 	params := responses.ResponseNewParams{
 		Model:        c.model,
-		Instructions: openai.String(prepareRecipeContextInstruction),
+		Instructions: openai.String(systemMessage),
 		// The API currently rejects zero output tokens, so keep this as low as allowed by the model.
 		MaxOutputTokens: openai.Int(16),
 		Input: responses.ResponseNewParamsInputUnion{
@@ -275,10 +276,19 @@ func responseUsageLogAttr(model string, usage responses.ResponseUsage) slog.Attr
 }
 
 func (c *client) buildRecipeContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
+	messages, err := c.buildSharedContextMessages(location, saleIngredients, instructions, date, lastRecipes)
+	if err != nil {
+		return nil, err
+	}
+	messages = append(messages, userPromptMessage("Default: total recipe time, including prep and all timed steps, should stay under 1 hour"))
+	messages = append(messages, userPromptMessage("Default: each recipe should serve 2 people."))
+	return messages, nil
+}
+
+func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
 	var messages []PromptMessage
 	// constants we might make variable later
 	messages = append(messages, userPromptMessage("Prioritize ingredients that are in season for the current date and user's state location "+date.Format("January 2nd")+" in "+location.State+"."))
-	messages = append(messages, userPromptMessage("Default: total recipe time, including prep and all timed steps, should stay under 1 hour"))
 	messages = append(messages, userPromptMessage("Default: cooking methods: oven, stove, grill, slow cooker"))
 
 	// todo reuse context via response id?
@@ -300,7 +310,6 @@ func (c *client) buildRecipeContextMessages(location *locationtypes.Location, sa
 	}
 
 	messages = append(messages, cleanInstructionMessages(instructions)...)
-	messages = append(messages, userPromptMessage("Default: each recipe should serve 2 people."))
 
 	return messages, nil
 }

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -84,8 +84,7 @@ type QuestionResponse struct {
 }
 
 type RecipeContext struct {
-	ResponseID     string
-	PromptCacheKey string
+	ResponseID string
 }
 
 // edited out. Which recipe should be richer?!
@@ -163,7 +162,7 @@ func (c *client) Regenerate(ctx context.Context, instructions []string, previous
 }
 
 func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
-	instructions []string, date time.Time, lastRecipes []string, promptCacheKey string,
+	instructions []string, date time.Time, lastRecipes []string,
 ) (*RecipeContext, error) {
 	promptMessages, err := c.buildRecipeContextMessages(location, saleIngredients, instructions, date, lastRecipes)
 	if err != nil {
@@ -181,10 +180,6 @@ func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtyp
 		},
 		Store: openai.Bool(true),
 	}
-	promptCacheKey = strings.TrimSpace(promptCacheKey)
-	if promptCacheKey != "" {
-		params.PromptCacheKey = openai.String(promptCacheKey)
-	}
 	resp, err := c.oai.Responses.New(ctx, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare recipe context: %w", err)
@@ -194,7 +189,7 @@ func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtyp
 	}
 	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
 	slog.InfoContext(ctx, "prepared recipe context", "ai_category", aiCategoryRecipe, "model", c.model, responseUsageLogAttr(c.model, resp.Usage))
-	return &RecipeContext{ResponseID: resp.ID, PromptCacheKey: promptCacheKey}, nil
+	return &RecipeContext{ResponseID: resp.ID}, nil
 }
 
 func (c *client) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext RecipeContext) (*Recipe, error) {
@@ -212,9 +207,6 @@ func (c *client) GenerateRecipeFromContext(ctx context.Context, instructions []s
 		},
 		Store: openai.Bool(true),
 		Text:  scheme(c.recipeSchema),
-	}
-	if strings.TrimSpace(recipeContext.PromptCacheKey) != "" {
-		params.PromptCacheKey = openai.String(recipeContext.PromptCacheKey)
 	}
 	resp, err := c.oai.Responses.New(ctx, params)
 	if err != nil {

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -162,7 +162,6 @@ func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtyp
 	if err != nil {
 		return "", fmt.Errorf("failed to build recipe context messages: %w", err)
 	}
-	promptMessages = append(promptMessages, userPromptMessage("Default: each recipe should serve 2 people."))
 
 	params := responses.ResponseNewParams{
 		Model:           c.model,
@@ -259,26 +258,6 @@ func responseUsageLogAttr(model string, usage responses.ResponseUsage) slog.Attr
 	)
 }
 
-func (c *client) GenerateRecipe(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
-	instructions []string, date time.Time, lastRecipes []string,
-) (*Recipe, error) {
-	contextID, err := c.PrepareRecipeContext(ctx, location, saleIngredients, nil, date, lastRecipes)
-	if err != nil {
-		return nil, err
-	}
-	return c.GenerateRecipeFromContext(ctx, instructions, contextID)
-}
-
-// buildRecipeMessages creates separate messages for the LLM to process more efficiently
-func (c *client) buildRecipeMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
-	messages, err := c.buildRecipeContextMessages(location, saleIngredients, instructions, date, lastRecipes)
-	if err != nil {
-		return nil, err
-	}
-	messages = append(messages, userPromptMessage("Default: each recipe should serve 2 people."))
-	return messages, nil
-}
-
 func (c *client) buildRecipeContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
 	var messages []PromptMessage
 	// constants we might make variable later
@@ -305,6 +284,7 @@ func (c *client) buildRecipeContextMessages(location *locationtypes.Location, sa
 	}
 
 	messages = append(messages, cleanInstructionMessages(instructions)...)
+	messages = append(messages, userPromptMessage("Default: each recipe should serve 2 people."))
 
 	return messages, nil
 }

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -20,8 +20,6 @@ import (
 
 const defaultRecipeModel = "gpt-5.5"
 
-const prepareRecipeContextInstruction = "Store this recipe context for follow-up recipe generation. Reply exactly: OK"
-
 // how close should this be to Input ingredint. Should we also add aisle or just echo productid so we can look it up
 type Ingredient struct {
 	ProductID   string `json:"id"`
@@ -80,10 +78,6 @@ type ShoppingList struct {
 // question threads go off from the response that generated the recipe.
 type QuestionResponse struct {
 	Answer     string
-	ResponseID string
-}
-
-type RecipeContext struct {
 	ResponseID string
 }
 
@@ -161,43 +155,15 @@ func (c *client) Regenerate(ctx context.Context, instructions []string, previous
 	return responseToRecipe(ctx, aiCategoryRecipe, c.model, resp)
 }
 
-func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time) (*RecipeContext, error) {
-	promptMessages, err := c.buildSharedContextMessages(location, saleIngredients, date)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build recipe context messages: %w", err)
-	}
-	promptMessages = append(promptMessages, userPromptMessage(prepareRecipeContextInstruction))
-
-	params := responses.ResponseNewParams{
-		Model:        c.model,
-		Instructions: openai.String(systemMessage),
-		// The API currently rejects zero output tokens, so keep this as low as allowed by the model.
-		MaxOutputTokens: openai.Int(16),
-		Input: responses.ResponseNewParamsInputUnion{
-			OfInputItemList: messagesToInput(promptMessages),
-		},
-		Store: openai.Bool(true),
-	}
-	resp, err := c.oai.Responses.New(ctx, params)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare recipe context: %w", err)
-	}
-	if strings.TrimSpace(resp.ID) == "" {
-		return nil, fmt.Errorf("failed to get recipe context response ID")
-	}
-	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
-	slog.InfoContext(ctx, "prepared recipe context", "ai_category", aiCategoryRecipe, "model", c.model, responseUsageLogAttr(c.model, resp.Usage))
-	return &RecipeContext{ResponseID: resp.ID}, nil
-}
-
-func (c *client) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext RecipeContext) (*Recipe, error) {
-	if recipeContext.ResponseID == "" {
-		return nil, fmt.Errorf("response ID is required for recipe context generation")
+func (c *client) GenerateRecipe(ctx context.Context, instructions []string, menuResponseID string) (*Recipe, error) {
+	menuResponseID = strings.TrimSpace(menuResponseID)
+	if menuResponseID == "" {
+		return nil, fmt.Errorf("response ID is required for menu response generation")
 	}
 	promptMessages := cleanInstructionMessages(instructions)
 	params := responses.ResponseNewParams{
 		Model:              c.model,
-		PreviousResponseID: openai.String(recipeContext.ResponseID),
+		PreviousResponseID: openai.String(menuResponseID),
 		// Previous response IDs do not carry over top-level instructions.
 		Instructions: openai.String(systemMessage),
 		Input: responses.ResponseNewParamsInputUnion{
@@ -208,7 +174,7 @@ func (c *client) GenerateRecipeFromContext(ctx context.Context, instructions []s
 	}
 	resp, err := c.oai.Responses.New(ctx, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate recipe from context: %w", err)
+		return nil, fmt.Errorf("failed to generate recipe from menu response: %w", err)
 	}
 	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
 

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -155,6 +155,60 @@ func (c *client) Regenerate(ctx context.Context, instructions []string, previous
 	return responseToRecipe(ctx, aiCategoryRecipe, c.model, resp)
 }
 
+func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
+	instructions []string, date time.Time, lastRecipes []string,
+) (string, error) {
+	promptMessages, err := c.buildRecipeContextMessages(location, saleIngredients, instructions, date, lastRecipes)
+	if err != nil {
+		return "", fmt.Errorf("failed to build recipe context messages: %w", err)
+	}
+	promptMessages = append(promptMessages, userPromptMessage("Default: each recipe should serve 2 people."))
+
+	params := responses.ResponseNewParams{
+		Model:           c.model,
+		MaxOutputTokens: openai.Int(0),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: messagesToInput(promptMessages),
+		},
+		Store: openai.Bool(true),
+	}
+	resp, err := c.oai.Responses.New(ctx, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare recipe context: %w", err)
+	}
+	if strings.TrimSpace(resp.ID) == "" {
+		return "", fmt.Errorf("failed to get recipe context response ID")
+	}
+	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
+	slog.InfoContext(ctx, "prepared recipe context", "ai_category", aiCategoryRecipe, "model", c.model, responseUsageLogAttr(c.model, resp.Usage))
+	return resp.ID, nil
+}
+
+func (c *client) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*Recipe, error) {
+	if previousResponseID == "" {
+		return nil, fmt.Errorf("response ID is required for recipe context generation")
+	}
+	promptMessages := cleanInstructionMessages(instructions)
+	params := responses.ResponseNewParams{
+		Model:              c.model,
+		PreviousResponseID: openai.String(previousResponseID),
+		// Previous response IDs do not carry over top-level instructions.
+		Instructions: openai.String(systemMessage),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: messagesToInput(promptMessages),
+		},
+		Store: openai.Bool(true),
+		Text:  scheme(c.recipeSchema),
+	}
+	resp, err := c.oai.Responses.New(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate recipe from context: %w", err)
+	}
+	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
+
+	return responseToRecipe(ctx, aiCategoryRecipe, c.model, resp)
+}
+
 func (c *client) AskQuestion(ctx context.Context, question string, previousResponseID string) (*QuestionResponse, error) {
 	question = strings.TrimSpace(question)
 	if question == "" {
@@ -208,27 +262,11 @@ func responseUsageLogAttr(model string, usage responses.ResponseUsage) slog.Attr
 func (c *client) GenerateRecipe(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
 	instructions []string, date time.Time, lastRecipes []string,
 ) (*Recipe, error) {
-	promptMessages, err := c.buildRecipeMessages(location, saleIngredients, instructions, date, lastRecipes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build recipe messages: %w", err)
-	}
-
-	params := responses.ResponseNewParams{
-		Model:        c.model,
-		Instructions: openai.String(systemMessage),
-		Input: responses.ResponseNewParamsInputUnion{
-			OfInputItemList: messagesToInput(promptMessages),
-		},
-		Store: openai.Bool(true),
-		Text:  scheme(c.recipeSchema),
-	}
-	resp, err := c.oai.Responses.New(ctx, params)
+	contextID, err := c.PrepareRecipeContext(ctx, location, saleIngredients, nil, date, lastRecipes)
 	if err != nil {
 		return nil, err
 	}
-	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
-
-	return responseToRecipe(ctx, aiCategoryRecipe, c.model, resp)
+	return c.GenerateRecipeFromContext(ctx, instructions, contextID)
 }
 
 // buildRecipeMessages creates separate messages for the LLM to process more efficiently

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -162,9 +162,9 @@ func (c *client) Regenerate(ctx context.Context, instructions []string, previous
 }
 
 func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
-	date time.Time, lastRecipes []string,
+	instructions []string, date time.Time, lastRecipes []string,
 ) (*RecipeContext, error) {
-	promptMessages, err := c.buildRecipeContextMessages(location, saleIngredients, date, lastRecipes)
+	promptMessages, err := c.buildRecipeContextMessages(location, saleIngredients, instructions, date, lastRecipes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build recipe context messages: %w", err)
 	}
@@ -267,8 +267,8 @@ func responseUsageLogAttr(model string, usage responses.ResponseUsage) slog.Attr
 	)
 }
 
-func (c *client) buildRecipeContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
-	messages, err := c.buildSharedContextMessages(location, saleIngredients, date, lastRecipes)
+func (c *client) buildRecipeContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
+	messages, err := c.buildSharedContextMessages(location, saleIngredients, instructions, date, lastRecipes)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func (c *client) buildRecipeContextMessages(location *locationtypes.Location, sa
 	return messages, nil
 }
 
-func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
+func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
 	var messages []PromptMessage
 	// constants we might make variable later
 	messages = append(messages, userPromptMessage("Prioritize ingredients that are in season for the current date and user's state location "+date.Format("January 2nd")+" in "+location.State+"."))
@@ -300,6 +300,8 @@ func (c *client) buildSharedContextMessages(location *locationtypes.Location, sa
 		}
 		messages = append(messages, userPromptMessage(prevRecipesMsg.String()))
 	}
+
+	messages = append(messages, cleanInstructionMessages(instructions)...)
 
 	return messages, nil
 }

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -20,6 +20,8 @@ import (
 
 const defaultRecipeModel = "gpt-5.5"
 
+const prepareRecipeContextInstruction = "Store this recipe context for follow-up recipe generation. Reply exactly: OK"
+
 // how close should this be to Input ingredint. Should we also add aisle or just echo productid so we can look it up
 type Ingredient struct {
 	ProductID   string `json:"id"`
@@ -79,6 +81,11 @@ type ShoppingList struct {
 type QuestionResponse struct {
 	Answer     string
 	ResponseID string
+}
+
+type RecipeContext struct {
+	ResponseID     string
+	PromptCacheKey string
 }
 
 // edited out. Which recipe should be richer?!
@@ -156,41 +163,47 @@ func (c *client) Regenerate(ctx context.Context, instructions []string, previous
 }
 
 func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
-	instructions []string, date time.Time, lastRecipes []string,
-) (string, error) {
+	instructions []string, date time.Time, lastRecipes []string, promptCacheKey string,
+) (*RecipeContext, error) {
 	promptMessages, err := c.buildRecipeContextMessages(location, saleIngredients, instructions, date, lastRecipes)
 	if err != nil {
-		return "", fmt.Errorf("failed to build recipe context messages: %w", err)
+		return nil, fmt.Errorf("failed to build recipe context messages: %w", err)
 	}
 
 	params := responses.ResponseNewParams{
-		Model:           c.model,
-		MaxOutputTokens: openai.Int(0),
+		Model:        c.model,
+		Instructions: openai.String(prepareRecipeContextInstruction),
+		// The API currently rejects zero output tokens, so keep this as low as allowed by the model.
+		MaxOutputTokens: openai.Int(16),
 		Input: responses.ResponseNewParamsInputUnion{
 			OfInputItemList: messagesToInput(promptMessages),
 		},
 		Store: openai.Bool(true),
 	}
+	promptCacheKey = strings.TrimSpace(promptCacheKey)
+	if promptCacheKey != "" {
+		params.PromptCacheKey = openai.String(promptCacheKey)
+	}
 	resp, err := c.oai.Responses.New(ctx, params)
 	if err != nil {
-		return "", fmt.Errorf("failed to prepare recipe context: %w", err)
+		return nil, fmt.Errorf("failed to prepare recipe context: %w", err)
 	}
 	if strings.TrimSpace(resp.ID) == "" {
-		return "", fmt.Errorf("failed to get recipe context response ID")
+		return nil, fmt.Errorf("failed to get recipe context response ID")
 	}
 	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
 	slog.InfoContext(ctx, "prepared recipe context", "ai_category", aiCategoryRecipe, "model", c.model, responseUsageLogAttr(c.model, resp.Usage))
-	return resp.ID, nil
+	return &RecipeContext{ResponseID: resp.ID, PromptCacheKey: promptCacheKey}, nil
 }
 
-func (c *client) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*Recipe, error) {
-	if previousResponseID == "" {
+func (c *client) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext RecipeContext) (*Recipe, error) {
+	if recipeContext.ResponseID == "" {
 		return nil, fmt.Errorf("response ID is required for recipe context generation")
 	}
 	promptMessages := cleanInstructionMessages(instructions)
 	params := responses.ResponseNewParams{
 		Model:              c.model,
-		PreviousResponseID: openai.String(previousResponseID),
+		PreviousResponseID: openai.String(recipeContext.ResponseID),
 		// Previous response IDs do not carry over top-level instructions.
 		Instructions: openai.String(systemMessage),
 		Input: responses.ResponseNewParamsInputUnion{
@@ -198,6 +211,9 @@ func (c *client) GenerateRecipeFromContext(ctx context.Context, instructions []s
 		},
 		Store: openai.Bool(true),
 		Text:  scheme(c.recipeSchema),
+	}
+	if strings.TrimSpace(recipeContext.PromptCacheKey) != "" {
+		params.PromptCacheKey = openai.String(recipeContext.PromptCacheKey)
 	}
 	resp, err := c.oai.Responses.New(ctx, params)
 	if err != nil {

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -161,10 +161,8 @@ func (c *client) Regenerate(ctx context.Context, instructions []string, previous
 	return responseToRecipe(ctx, aiCategoryRecipe, c.model, resp)
 }
 
-func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
-	instructions []string, date time.Time, lastRecipes []string,
-) (*RecipeContext, error) {
-	promptMessages, err := c.buildRecipeContextMessages(location, saleIngredients, instructions, date, lastRecipes)
+func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time) (*RecipeContext, error) {
+	promptMessages, err := c.buildSharedContextMessages(location, saleIngredients, date)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build recipe context messages: %w", err)
 	}
@@ -267,21 +265,11 @@ func responseUsageLogAttr(model string, usage responses.ResponseUsage) slog.Attr
 	)
 }
 
-func (c *client) buildRecipeContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
-	messages, err := c.buildSharedContextMessages(location, saleIngredients, instructions, date, lastRecipes)
-	if err != nil {
-		return nil, err
-	}
-	messages = append(messages, userPromptMessage("Default: total recipe time, including prep and all timed steps, should stay under 1 hour"))
-	messages = append(messages, userPromptMessage("Default: each recipe should serve 2 people."))
-	return messages, nil
-}
-
-func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
+// should just be directive for menu
+func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time) ([]PromptMessage, error) {
 	var messages []PromptMessage
 	// constants we might make variable later
 	messages = append(messages, userPromptMessage("Prioritize ingredients that are in season for the current date and user's state location "+date.Format("January 2nd")+" in "+location.State+"."))
-	messages = append(messages, userPromptMessage("Default: cooking methods: oven, stove, grill, slow cooker"))
 
 	// todo reuse context via response id?
 	ingredientsMessage := fmt.Sprintf("%d ingredients available in TSV format with header.\n", len(saleIngredients))
@@ -291,17 +279,6 @@ func (c *client) buildSharedContextMessages(location *locationtypes.Location, sa
 	}
 	ingredientsMessage += buf.String()
 	messages = append(messages, userPromptMessage(ingredientsMessage))
-
-	if len(lastRecipes) > 0 {
-		var prevRecipesMsg strings.Builder
-		prevRecipesMsg.WriteString("Avoid recipes similar to these previously cooked:\n")
-		for _, recipe := range lastRecipes {
-			fmt.Fprintf(&prevRecipesMsg, "%s\n", recipe)
-		}
-		messages = append(messages, userPromptMessage(prevRecipesMsg.String()))
-	}
-
-	messages = append(messages, cleanInstructionMessages(instructions)...)
 
 	return messages, nil
 }

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -162,9 +162,9 @@ func (c *client) Regenerate(ctx context.Context, instructions []string, previous
 }
 
 func (c *client) PrepareRecipeContext(ctx context.Context, location *locationtypes.Location, saleIngredients []InputIngredient,
-	instructions []string, date time.Time, lastRecipes []string,
+	date time.Time, lastRecipes []string,
 ) (*RecipeContext, error) {
-	promptMessages, err := c.buildRecipeContextMessages(location, saleIngredients, instructions, date, lastRecipes)
+	promptMessages, err := c.buildRecipeContextMessages(location, saleIngredients, date, lastRecipes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build recipe context messages: %w", err)
 	}
@@ -267,8 +267,8 @@ func responseUsageLogAttr(model string, usage responses.ResponseUsage) slog.Attr
 	)
 }
 
-func (c *client) buildRecipeContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
-	messages, err := c.buildSharedContextMessages(location, saleIngredients, instructions, date, lastRecipes)
+func (c *client) buildRecipeContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
+	messages, err := c.buildSharedContextMessages(location, saleIngredients, date, lastRecipes)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func (c *client) buildRecipeContextMessages(location *locationtypes.Location, sa
 	return messages, nil
 }
 
-func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, instructions []string, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
+func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time, lastRecipes []string) ([]PromptMessage, error) {
 	var messages []PromptMessage
 	// constants we might make variable later
 	messages = append(messages, userPromptMessage("Prioritize ingredients that are in season for the current date and user's state location "+date.Format("January 2nd")+" in "+location.State+"."))
@@ -300,8 +300,6 @@ func (c *client) buildSharedContextMessages(location *locationtypes.Location, sa
 		}
 		messages = append(messages, userPromptMessage(prevRecipesMsg.String()))
 	}
-
-	messages = append(messages, cleanInstructionMessages(instructions)...)
 
 	return messages, nil
 }

--- a/internal/ai/recipe.go
+++ b/internal/ai/recipe.go
@@ -9,9 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"strings"
-	"time"
-
-	locationtypes "careme/internal/locations/types"
 
 	openai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/responses"
@@ -229,24 +226,6 @@ func responseUsageLogAttr(model string, usage responses.ResponseUsage) slog.Attr
 		slog.Int64("totalTokens", usage.TotalTokens),
 		estimatedSpendLogAttr(estimateOpenAIResponseSpend(model, usage.InputTokens, usage.InputTokensDetails.CachedTokens, usage.OutputTokens)),
 	)
-}
-
-// should just be directive for menu
-func (c *client) buildSharedContextMessages(location *locationtypes.Location, saleIngredients []InputIngredient, date time.Time) ([]PromptMessage, error) {
-	var messages []PromptMessage
-	// constants we might make variable later
-	messages = append(messages, userPromptMessage("Prioritize ingredients that are in season for the current date and user's state location "+date.Format("January 2nd")+" in "+location.State+"."))
-
-	// todo reuse context via response id?
-	ingredientsMessage := fmt.Sprintf("%d ingredients available in TSV format with header.\n", len(saleIngredients))
-	var buf strings.Builder
-	if err := InputIngredientsToTSV(saleIngredients, &buf); err != nil {
-		return nil, fmt.Errorf("failed to convert ingredients to TSV: %w", err)
-	}
-	ingredientsMessage += buf.String()
-	messages = append(messages, userPromptMessage(ingredientsMessage))
-
-	return messages, nil
 }
 
 func normalizeRecipeWineStyles(styles []string) []string {

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -151,7 +151,7 @@ func TestPrepareRecipeContextStoresMinimalOutputResponse(t *testing.T) {
 	price := float32(8.99)
 	got, err := client.PrepareRecipeContext(t.Context(), &locationtypes.Location{State: "WA"}, []InputIngredient{
 		{ProductID: "chicken-1", Description: "Chicken thighs", Size: "2 lb", PriceRegular: &price},
-	}, []string{"Use sale ingredients."}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"})
+	}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"})
 	if err != nil {
 		t.Fatalf("PrepareRecipeContext returned error: %v", err)
 	}
@@ -173,6 +173,9 @@ func TestPrepareRecipeContextStoresMinimalOutputResponse(t *testing.T) {
 	}
 	if !strings.Contains(requestBody, "Chicken thighs") || !strings.Contains(requestBody, "Default: each recipe should serve 2 people.") {
 		t.Fatalf("expected shared ingredient and serving context in request: %s", requestBody)
+	}
+	if strings.Contains(requestBody, "Use sale ingredients.") {
+		t.Fatalf("recipe context should not receive planner instructions: %s", requestBody)
 	}
 	if !strings.Contains(requestBody, "professional chef and recipe developer") || !strings.Contains(requestBody, prepareRecipeContextInstruction) {
 		t.Fatalf("expected recipe system prompt and context seed instruction in request: %s", requestBody)

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -151,7 +151,7 @@ func TestPrepareRecipeContextStoresMinimalOutputResponse(t *testing.T) {
 	price := float32(8.99)
 	got, err := client.PrepareRecipeContext(t.Context(), &locationtypes.Location{State: "WA"}, []InputIngredient{
 		{ProductID: "chicken-1", Description: "Chicken thighs", Size: "2 lb", PriceRegular: &price},
-	}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"})
+	}, []string{"Use sale ingredients."}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"})
 	if err != nil {
 		t.Fatalf("PrepareRecipeContext returned error: %v", err)
 	}
@@ -173,9 +173,6 @@ func TestPrepareRecipeContextStoresMinimalOutputResponse(t *testing.T) {
 	}
 	if !strings.Contains(requestBody, "Chicken thighs") || !strings.Contains(requestBody, "Default: each recipe should serve 2 people.") {
 		t.Fatalf("expected shared ingredient and serving context in request: %s", requestBody)
-	}
-	if strings.Contains(requestBody, "Use sale ingredients.") {
-		t.Fatalf("recipe context should not receive planner instructions: %s", requestBody)
 	}
 	if !strings.Contains(requestBody, "professional chef and recipe developer") || !strings.Contains(requestBody, prepareRecipeContextInstruction) {
 		t.Fatalf("expected recipe system prompt and context seed instruction in request: %s", requestBody)

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -177,6 +177,9 @@ func TestPrepareRecipeContextStoresMinimalOutputResponseWithPromptCacheKey(t *te
 	if !strings.Contains(requestBody, "Chicken thighs") || !strings.Contains(requestBody, "Default: each recipe should serve 2 people.") {
 		t.Fatalf("expected shared ingredient and serving context in request: %s", requestBody)
 	}
+	if !strings.Contains(requestBody, "professional chef and recipe developer") || !strings.Contains(requestBody, prepareRecipeContextInstruction) {
+		t.Fatalf("expected recipe system prompt and context seed instruction in request: %s", requestBody)
+	}
 	if recorder.record == nil || recorder.record.ResponseID != "resp-shared-context" {
 		t.Fatalf("expected context prompt record, got %#v", recorder.record)
 	}

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -1,11 +1,18 @@
 package ai
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"reflect"
 	"slices"
 	"strings"
 	"testing"
+	"time"
+
+	locationtypes "careme/internal/locations/types"
 
 	"github.com/openai/openai-go/v3/responses"
 )
@@ -104,6 +111,136 @@ func TestSystemMessageRequiresPrepFirstAndTotalTiming(t *testing.T) {
 		if !strings.Contains(systemMessage, want) {
 			t.Fatalf("expected system message to contain %q", want)
 		}
+	}
+}
+
+func TestPrepareRecipeContextStoresZeroOutputResponse(t *testing.T) {
+	recorder := &capturePromptRecorder{}
+	var requestBody string
+	client := NewClient("test-key", "ignored", &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasSuffix(req.URL.Path, "/responses") {
+			t.Fatalf("unexpected OpenAI request path: %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		requestBody = string(body)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(fmt.Sprintf(`{
+				"id": "resp-shared-context",
+				"object": "response",
+				"created_at": 1778529600,
+				"status": "completed",
+				"model": %q,
+				"output": [],
+				"usage": {
+					"input_tokens": 120,
+					"input_tokens_details": {"cached_tokens": 0},
+					"output_tokens": 0,
+					"output_tokens_details": {"reasoning_tokens": 0},
+					"total_tokens": 120
+				}
+			}`, defaultRecipeModel))),
+			Request: req,
+		}, nil
+	})}, recorder)
+
+	price := float32(8.99)
+	got, err := client.PrepareRecipeContext(t.Context(), &locationtypes.Location{State: "WA"}, []InputIngredient{
+		{ProductID: "chicken-1", Description: "Chicken thighs", Size: "2 lb", PriceRegular: &price},
+	}, []string{"Use sale ingredients."}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"})
+	if err != nil {
+		t.Fatalf("PrepareRecipeContext returned error: %v", err)
+	}
+	if got != "resp-shared-context" {
+		t.Fatalf("unexpected context response id: %q", got)
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(requestBody), &body); err != nil {
+		t.Fatalf("unmarshal request body: %v\n%s", err, requestBody)
+	}
+	if body["max_output_tokens"] != float64(0) {
+		t.Fatalf("expected zero max output tokens, got %#v in %s", body["max_output_tokens"], requestBody)
+	}
+	if body["store"] != true {
+		t.Fatalf("expected stored response, got %s", requestBody)
+	}
+	if _, ok := body["text"]; ok {
+		t.Fatalf("context warmup should not request recipe JSON schema: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, "Chicken thighs") || !strings.Contains(requestBody, "Default: each recipe should serve 2 people.") {
+		t.Fatalf("expected shared ingredient and serving context in request: %s", requestBody)
+	}
+	if recorder.record == nil || recorder.record.ResponseID != "resp-shared-context" {
+		t.Fatalf("expected context prompt record, got %#v", recorder.record)
+	}
+}
+
+func TestGenerateRecipeFromContextUsesPreviousResponseWithoutIngredientTSV(t *testing.T) {
+	recorder := &capturePromptRecorder{}
+	var requestBody string
+	client := NewClient("test-key", "ignored", &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasSuffix(req.URL.Path, "/responses") {
+			t.Fatalf("unexpected OpenAI request path: %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		requestBody = string(body)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(fmt.Sprintf(`{
+				"id": "resp-recipe",
+				"object": "response",
+				"created_at": 1778529600,
+				"status": "completed",
+				"model": %q,
+				"output": [{
+					"id": "msg-recipe",
+					"type": "message",
+					"status": "completed",
+					"role": "assistant",
+					"content": [{
+						"type": "output_text",
+						"text": "{\"title\":\"Korean Chicken\",\"description\":\"Fast dinner.\",\"cook_time\":\"35 minutes\",\"cost_estimate\":\"$12\",\"ingredients\":[],\"instructions\":[\"Prep.\"],\"health\":\"Balanced.\",\"drink_pairing\":\"Water.\",\"wine_styles\":[]}",
+						"annotations": []
+					}]
+				}],
+				"usage": {
+					"input_tokens": 20,
+					"input_tokens_details": {"cached_tokens": 15},
+					"output_tokens": 5,
+					"output_tokens_details": {"reasoning_tokens": 0},
+					"total_tokens": 25
+				}
+			}`, defaultRecipeModel))),
+			Request: req,
+		}, nil
+	})}, recorder)
+
+	got, err := client.GenerateRecipeFromContext(t.Context(), []string{"Cuisine direction for this recipe: Korean."}, "resp-shared-context")
+	if err != nil {
+		t.Fatalf("GenerateRecipeFromContext returned error: %v", err)
+	}
+	if got.ResponseID != "resp-recipe" || got.Title != "Korean Chicken" {
+		t.Fatalf("unexpected recipe: %+v", got)
+	}
+	if strings.Contains(requestBody, "Chicken thighs") {
+		t.Fatalf("recipe continuation should not resend ingredient TSV: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, `"previous_response_id":"resp-shared-context"`) {
+		t.Fatalf("expected previous response id in request: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, "Cuisine direction for this recipe: Korean.") || !strings.Contains(requestBody, "professional chef and recipe developer") {
+		t.Fatalf("expected recipe instructions and system prompt in request: %s", requestBody)
+	}
+	if recorder.record == nil || recorder.record.PreviousResponseID != "resp-shared-context" {
+		t.Fatalf("expected prompt record parent response ID, got %#v", recorder.record)
 	}
 }
 

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -1,7 +1,6 @@
 package ai
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -10,9 +9,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-	"time"
-
-	locationtypes "careme/internal/locations/types"
 
 	"github.com/openai/openai-go/v3/responses"
 )
@@ -114,75 +110,7 @@ func TestSystemMessageRequiresPrepFirstAndTotalTiming(t *testing.T) {
 	}
 }
 
-func TestPrepareRecipeContextStoresMinimalOutputResponse(t *testing.T) {
-	recorder := &capturePromptRecorder{}
-	var requestBody string
-	client := NewClient("test-key", "ignored", &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasSuffix(req.URL.Path, "/responses") {
-			t.Fatalf("unexpected OpenAI request path: %s", req.URL.Path)
-		}
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			t.Fatalf("read request body: %v", err)
-		}
-		requestBody = string(body)
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-			Body: io.NopCloser(strings.NewReader(fmt.Sprintf(`{
-				"id": "resp-shared-context",
-				"object": "response",
-				"created_at": 1778529600,
-				"status": "completed",
-				"model": %q,
-				"output": [],
-				"usage": {
-					"input_tokens": 120,
-					"input_tokens_details": {"cached_tokens": 0},
-					"output_tokens": 0,
-					"output_tokens_details": {"reasoning_tokens": 0},
-					"total_tokens": 120
-				}
-			}`, defaultRecipeModel))),
-			Request: req,
-		}, nil
-	})}, recorder)
-
-	price := float32(8.99)
-	got, err := client.PrepareRecipeContext(t.Context(), &locationtypes.Location{State: "WA"}, []InputIngredient{
-		{ProductID: "chicken-1", Description: "Chicken thighs", Size: "2 lb", PriceRegular: &price},
-	}, []string{"Use sale ingredients."}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"})
-	if err != nil {
-		t.Fatalf("PrepareRecipeContext returned error: %v", err)
-	}
-	if got.ResponseID != "resp-shared-context" {
-		t.Fatalf("unexpected recipe context: %#v", got)
-	}
-	var body map[string]any
-	if err := json.Unmarshal([]byte(requestBody), &body); err != nil {
-		t.Fatalf("unmarshal request body: %v\n%s", err, requestBody)
-	}
-	if body["max_output_tokens"] != float64(16) {
-		t.Fatalf("expected minimal max output tokens, got %#v in %s", body["max_output_tokens"], requestBody)
-	}
-	if body["store"] != true {
-		t.Fatalf("expected stored response, got %s", requestBody)
-	}
-	if _, ok := body["text"]; ok {
-		t.Fatalf("context warmup should not request recipe JSON schema: %s", requestBody)
-	}
-	if !strings.Contains(requestBody, "Chicken thighs") || !strings.Contains(requestBody, "Default: each recipe should serve 2 people.") {
-		t.Fatalf("expected shared ingredient and serving context in request: %s", requestBody)
-	}
-	if !strings.Contains(requestBody, "professional chef and recipe developer") || !strings.Contains(requestBody, prepareRecipeContextInstruction) {
-		t.Fatalf("expected recipe system prompt and context seed instruction in request: %s", requestBody)
-	}
-	if recorder.record == nil || recorder.record.ResponseID != "resp-shared-context" {
-		t.Fatalf("expected context prompt record, got %#v", recorder.record)
-	}
-}
-
-func TestGenerateRecipeFromContextUsesPreviousResponseWithoutIngredientTSV(t *testing.T) {
+func TestGenerateRecipeUsesMenuResponseIDWithoutIngredientTSV(t *testing.T) {
 	recorder := &capturePromptRecorder{}
 	var requestBody string
 	client := NewClient("test-key", "ignored", &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -226,9 +154,9 @@ func TestGenerateRecipeFromContextUsesPreviousResponseWithoutIngredientTSV(t *te
 		}, nil
 	})}, recorder)
 
-	got, err := client.GenerateRecipeFromContext(t.Context(), []string{"Cuisine direction for this recipe: Korean."}, RecipeContext{ResponseID: "resp-shared-context"})
+	got, err := client.GenerateRecipe(t.Context(), []string{"Cuisine direction for this recipe: Korean."}, "resp-menu-plan")
 	if err != nil {
-		t.Fatalf("GenerateRecipeFromContext returned error: %v", err)
+		t.Fatalf("GenerateRecipe returned error: %v", err)
 	}
 	if got.ResponseID != "resp-recipe" || got.Title != "Korean Chicken" {
 		t.Fatalf("unexpected recipe: %+v", got)
@@ -236,13 +164,13 @@ func TestGenerateRecipeFromContextUsesPreviousResponseWithoutIngredientTSV(t *te
 	if strings.Contains(requestBody, "Chicken thighs") {
 		t.Fatalf("recipe continuation should not resend ingredient TSV: %s", requestBody)
 	}
-	if !strings.Contains(requestBody, `"previous_response_id":"resp-shared-context"`) {
+	if !strings.Contains(requestBody, `"previous_response_id":"resp-menu-plan"`) {
 		t.Fatalf("expected previous response id in request: %s", requestBody)
 	}
 	if !strings.Contains(requestBody, "Cuisine direction for this recipe: Korean.") || !strings.Contains(requestBody, "professional chef and recipe developer") {
 		t.Fatalf("expected recipe instructions and system prompt in request: %s", requestBody)
 	}
-	if recorder.record == nil || recorder.record.PreviousResponseID != "resp-shared-context" {
+	if recorder.record == nil || recorder.record.PreviousResponseID != "resp-menu-plan" {
 		t.Fatalf("expected prompt record parent response ID, got %#v", recorder.record)
 	}
 }

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -114,7 +114,7 @@ func TestSystemMessageRequiresPrepFirstAndTotalTiming(t *testing.T) {
 	}
 }
 
-func TestPrepareRecipeContextStoresMinimalOutputResponseWithPromptCacheKey(t *testing.T) {
+func TestPrepareRecipeContextStoresMinimalOutputResponse(t *testing.T) {
 	recorder := &capturePromptRecorder{}
 	var requestBody string
 	client := NewClient("test-key", "ignored", &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -151,11 +151,11 @@ func TestPrepareRecipeContextStoresMinimalOutputResponseWithPromptCacheKey(t *te
 	price := float32(8.99)
 	got, err := client.PrepareRecipeContext(t.Context(), &locationtypes.Location{State: "WA"}, []InputIngredient{
 		{ProductID: "chicken-1", Description: "Chicken thighs", Size: "2 lb", PriceRegular: &price},
-	}, []string{"Use sale ingredients."}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"}, "ingredients-test-cache-key")
+	}, []string{"Use sale ingredients."}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"})
 	if err != nil {
 		t.Fatalf("PrepareRecipeContext returned error: %v", err)
 	}
-	if got.ResponseID != "resp-shared-context" || got.PromptCacheKey != "ingredients-test-cache-key" {
+	if got.ResponseID != "resp-shared-context" {
 		t.Fatalf("unexpected recipe context: %#v", got)
 	}
 	var body map[string]any
@@ -164,9 +164,6 @@ func TestPrepareRecipeContextStoresMinimalOutputResponseWithPromptCacheKey(t *te
 	}
 	if body["max_output_tokens"] != float64(16) {
 		t.Fatalf("expected minimal max output tokens, got %#v in %s", body["max_output_tokens"], requestBody)
-	}
-	if body["prompt_cache_key"] != "ingredients-test-cache-key" {
-		t.Fatalf("expected prompt cache key, got %#v in %s", body["prompt_cache_key"], requestBody)
 	}
 	if body["store"] != true {
 		t.Fatalf("expected stored response, got %s", requestBody)
@@ -229,10 +226,7 @@ func TestGenerateRecipeFromContextUsesPreviousResponseWithoutIngredientTSV(t *te
 		}, nil
 	})}, recorder)
 
-	got, err := client.GenerateRecipeFromContext(t.Context(), []string{"Cuisine direction for this recipe: Korean."}, RecipeContext{
-		ResponseID:     "resp-shared-context",
-		PromptCacheKey: "ingredients-test-cache-key",
-	})
+	got, err := client.GenerateRecipeFromContext(t.Context(), []string{"Cuisine direction for this recipe: Korean."}, RecipeContext{ResponseID: "resp-shared-context"})
 	if err != nil {
 		t.Fatalf("GenerateRecipeFromContext returned error: %v", err)
 	}
@@ -244,9 +238,6 @@ func TestGenerateRecipeFromContextUsesPreviousResponseWithoutIngredientTSV(t *te
 	}
 	if !strings.Contains(requestBody, `"previous_response_id":"resp-shared-context"`) {
 		t.Fatalf("expected previous response id in request: %s", requestBody)
-	}
-	if !strings.Contains(requestBody, `"prompt_cache_key":"ingredients-test-cache-key"`) {
-		t.Fatalf("expected prompt cache key in request: %s", requestBody)
 	}
 	if !strings.Contains(requestBody, "Cuisine direction for this recipe: Korean.") || !strings.Contains(requestBody, "professional chef and recipe developer") {
 		t.Fatalf("expected recipe instructions and system prompt in request: %s", requestBody)

--- a/internal/ai/recipe_test.go
+++ b/internal/ai/recipe_test.go
@@ -114,7 +114,7 @@ func TestSystemMessageRequiresPrepFirstAndTotalTiming(t *testing.T) {
 	}
 }
 
-func TestPrepareRecipeContextStoresZeroOutputResponse(t *testing.T) {
+func TestPrepareRecipeContextStoresMinimalOutputResponseWithPromptCacheKey(t *testing.T) {
 	recorder := &capturePromptRecorder{}
 	var requestBody string
 	client := NewClient("test-key", "ignored", &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -151,19 +151,22 @@ func TestPrepareRecipeContextStoresZeroOutputResponse(t *testing.T) {
 	price := float32(8.99)
 	got, err := client.PrepareRecipeContext(t.Context(), &locationtypes.Location{State: "WA"}, []InputIngredient{
 		{ProductID: "chicken-1", Description: "Chicken thighs", Size: "2 lb", PriceRegular: &price},
-	}, []string{"Use sale ingredients."}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"})
+	}, []string{"Use sale ingredients."}, time.Date(2026, time.May, 11, 0, 0, 0, 0, time.UTC), []string{"Lemon pasta"}, "ingredients-test-cache-key")
 	if err != nil {
 		t.Fatalf("PrepareRecipeContext returned error: %v", err)
 	}
-	if got != "resp-shared-context" {
-		t.Fatalf("unexpected context response id: %q", got)
+	if got.ResponseID != "resp-shared-context" || got.PromptCacheKey != "ingredients-test-cache-key" {
+		t.Fatalf("unexpected recipe context: %#v", got)
 	}
 	var body map[string]any
 	if err := json.Unmarshal([]byte(requestBody), &body); err != nil {
 		t.Fatalf("unmarshal request body: %v\n%s", err, requestBody)
 	}
-	if body["max_output_tokens"] != float64(0) {
-		t.Fatalf("expected zero max output tokens, got %#v in %s", body["max_output_tokens"], requestBody)
+	if body["max_output_tokens"] != float64(16) {
+		t.Fatalf("expected minimal max output tokens, got %#v in %s", body["max_output_tokens"], requestBody)
+	}
+	if body["prompt_cache_key"] != "ingredients-test-cache-key" {
+		t.Fatalf("expected prompt cache key, got %#v in %s", body["prompt_cache_key"], requestBody)
 	}
 	if body["store"] != true {
 		t.Fatalf("expected stored response, got %s", requestBody)
@@ -223,7 +226,10 @@ func TestGenerateRecipeFromContextUsesPreviousResponseWithoutIngredientTSV(t *te
 		}, nil
 	})}, recorder)
 
-	got, err := client.GenerateRecipeFromContext(t.Context(), []string{"Cuisine direction for this recipe: Korean."}, "resp-shared-context")
+	got, err := client.GenerateRecipeFromContext(t.Context(), []string{"Cuisine direction for this recipe: Korean."}, RecipeContext{
+		ResponseID:     "resp-shared-context",
+		PromptCacheKey: "ingredients-test-cache-key",
+	})
 	if err != nil {
 		t.Fatalf("GenerateRecipeFromContext returned error: %v", err)
 	}
@@ -235,6 +241,9 @@ func TestGenerateRecipeFromContextUsesPreviousResponseWithoutIngredientTSV(t *te
 	}
 	if !strings.Contains(requestBody, `"previous_response_id":"resp-shared-context"`) {
 		t.Fatalf("expected previous response id in request: %s", requestBody)
+	}
+	if !strings.Contains(requestBody, `"prompt_cache_key":"ingredients-test-cache-key"`) {
+		t.Fatalf("expected prompt cache key in request: %s", requestBody)
 	}
 	if !strings.Contains(requestBody, "Cuisine direction for this recipe: Korean.") || !strings.Contains(requestBody, "professional chef and recipe developer") {
 		t.Fatalf("expected recipe instructions and system prompt in request: %s", requestBody)

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -25,7 +25,7 @@ const IngredientGradeCutoff = 6
 type aiClient interface {
 	CreateMenuPlan(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, count int) (*ai.MenuPlan, error)
 	RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error)
-	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error)
+	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error)
 	GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error)
 	Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
@@ -157,7 +157,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 		}()
 		go func() {
-			recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes)
+			recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, p.Date, p.LastRecipes)
 			contextCh <- asyncContextResult{context: recipeContext, err: err}
 		}()
 
@@ -247,7 +247,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 	}()
 	go func() {
-		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes)
+		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, p.Date, p.LastRecipes)
 		contextCh <- asyncContextResult{context: recipeContext, err: err}
 	}()
 

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -25,7 +25,7 @@ const IngredientGradeCutoff = 6
 type aiClient interface {
 	CreateMenuPlan(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, count int) (*ai.MenuPlan, error)
 	RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error)
-	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error)
+	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error)
 	GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error)
 	Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
@@ -157,7 +157,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 		}()
 		go func() {
-			recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, p.Date, p.LastRecipes)
+			recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes)
 			contextCh <- asyncContextResult{context: recipeContext, err: err}
 		}()
 
@@ -247,7 +247,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 	}()
 	go func() {
-		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, p.Date, p.LastRecipes)
+		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes)
 		contextCh <- asyncContextResult{context: recipeContext, err: err}
 	}()
 

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -144,19 +144,13 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			return nil, fmt.Errorf("failed to plan recipe replacements: %w", err)
 		}
 		g.writeStatus(ctx, hash, plan.String())
-
 		menuResponseID := strings.TrimSpace(plan.ResponseID)
-		if menuResponseID == "" {
-			return nil, fmt.Errorf("failed to plan recipe replacements: AI returned no menu plan response ID")
-		}
 
 		results, err := parallelism.MapWithErrors(plan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 			ctx, span := tracer.Start(ctx, "recipes.regenerate.single")
 			defer span.End()
 
-			// start fresh here?
-			instructions := append(slices.Clone(regenInstructions), plan.Instructions()...)
-			recipe, err := g.aiClient.GenerateRecipe(ctx, instructions, menuResponseID)
+			recipe, err := g.aiClient.GenerateRecipe(ctx, plan.Instructions(), menuResponseID)
 			if err != nil {
 				return nil, err
 			}
@@ -204,13 +198,8 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 	if err != nil {
 		return nil, fmt.Errorf("failed to plan recipe variety: %w", err)
 	}
-	if menuPlan == nil {
-		return nil, fmt.Errorf("failed to plan recipe variety: AI returned no menu plan")
-	}
 	menuResponseID := strings.TrimSpace(menuPlan.ResponseID)
-	if menuResponseID == "" {
-		return nil, fmt.Errorf("failed to plan recipe variety: AI returned no menu plan response ID")
-	}
+
 	g.writeStatus(ctx, hash, menuPlan.String())
 
 	results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
@@ -241,20 +230,23 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 }
 
 func (g *generatorService) replacementMenuPlan(ctx context.Context, p *generatorParams, instructions []string, count int) (*ai.MenuPlan, error) {
-	if strings.TrimSpace(p.PreviousMenuPlanResponseID) != "" {
-		plan, err := g.aiClient.RegenerateMenuPlan(ctx, instructions, p.PreviousMenuPlanResponseID, count)
-		if err != nil {
-			return nil, err
-		}
-		if plan == nil {
-			return nil, fmt.Errorf("AI returned no menu plan")
-		}
-		if len(plan.Plans) == 0 {
-			return nil, fmt.Errorf("planned 0 replacement recipes")
-		}
-		return plan, nil
+	if strings.TrimSpace(p.PreviousMenuPlanResponseID) == "" {
+		return nil, fmt.Errorf("missing previous menu plan response ID for menu")
 	}
-	return nil, fmt.Errorf("missing previous menu plan response ID for menu date %s", p.Date.Format("2006-01-02"))
+	plan, err := g.aiClient.RegenerateMenuPlan(ctx, instructions, p.PreviousMenuPlanResponseID, count)
+	if err != nil {
+		return nil, err
+	}
+	if plan == nil {
+		return nil, fmt.Errorf("AI returned no menu plan")
+	}
+	if len(plan.Plans) == 0 {
+		return nil, fmt.Errorf("planned 0 replacement recipes")
+	}
+	if strings.TrimSpace(plan.ResponseID) == "" {
+		return nil, fmt.Errorf("failed to plan recipe replacements: AI returned no menu plan response ID")
+	}
+	return plan, nil
 }
 
 // generator not prociding a lot of value here. Should sever just hold an ai client?

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -25,9 +25,7 @@ const IngredientGradeCutoff = 6
 type aiClient interface {
 	CreateMenuPlan(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, count int) (*ai.MenuPlan, error)
 	RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error)
-	// should last recipes just be sent to menuplan?
-	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time) (*ai.RecipeContext, error)
-	GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error)
+	GenerateRecipe(ctx context.Context, instructions []string, menuResponseID string) (*ai.Recipe, error)
 	Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
 	PickWine(ctx context.Context, recipe ai.Recipe, wines []ai.InputIngredient) (*ai.WineSelection, error)
@@ -51,8 +49,6 @@ type generatorService struct {
 }
 
 var tracer = otel.Tracer("careme/internal/recipes")
-
-var menuPlanResponseIDBackCompatLastDate = time.Date(2026, time.May, 24, 0, 0, 0, 0, time.UTC)
 
 func NewGenerator(aiClient aiClient, critiquer critique.Service, staples staplesService, statuses statusWriter, recipeSaver recipeSaver) (*generatorService, error) {
 	if aiClient == nil {
@@ -149,9 +145,9 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		}
 		g.writeStatus(ctx, hash, plan.String())
 
-		// better to save the intiial recipe context like we save PreviousMenuPlanResponseID
-		rctx := ai.RecipeContext{
-			ResponseID: p.Dismissed[0].ResponseID,
+		menuResponseID := strings.TrimSpace(plan.ResponseID)
+		if menuResponseID == "" {
+			return nil, fmt.Errorf("failed to plan recipe replacements: AI returned no menu plan response ID")
 		}
 
 		results, err := parallelism.MapWithErrors(plan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
@@ -160,7 +156,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 
 			// start fresh here?
 			instructions := append(slices.Clone(regenInstructions), plan.Instructions()...)
-			recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, instructions, rctx)
+			recipe, err := g.aiClient.GenerateRecipe(ctx, instructions, menuResponseID)
 			if err != nil {
 				return nil, err
 			}
@@ -204,38 +200,16 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 
 	menuPlanInstructions := []string{p.Directive, p.Instructions}
 
-	type asyncMenuPlanResult struct {
-		plan *ai.MenuPlan
-		err  error
+	menuPlan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, 3)
+	if err != nil {
+		return nil, fmt.Errorf("failed to plan recipe variety: %w", err)
 	}
-	type asyncContextResult struct {
-		context *ai.RecipeContext
-		err     error
+	if menuPlan == nil {
+		return nil, fmt.Errorf("failed to plan recipe variety: AI returned no menu plan")
 	}
-	menuPlanCh := make(chan asyncMenuPlanResult, 1)
-	contextCh := make(chan asyncContextResult, 1)
-	go func() {
-		plan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, 3)
-		menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
-	}()
-	go func() {
-		// not clear this gets us any extra caching. Does it get us speed?
-		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, p.Date)
-		contextCh <- asyncContextResult{context: recipeContext, err: err}
-	}()
-
-	menuPlanResult := <-menuPlanCh
-	contextResult := <-contextCh
-	if menuPlanResult.err != nil {
-		return nil, fmt.Errorf("failed to plan recipe variety: %w", menuPlanResult.err)
-	}
-	if contextResult.err != nil {
-		return nil, fmt.Errorf("failed to prepare recipe context: %w", contextResult.err)
-	}
-	menuPlan := menuPlanResult.plan
-	recipeContext := contextResult.context
-	if recipeContext == nil {
-		return nil, fmt.Errorf("failed to prepare recipe context: AI returned no recipe context")
+	menuResponseID := strings.TrimSpace(menuPlan.ResponseID)
+	if menuResponseID == "" {
+		return nil, fmt.Errorf("failed to plan recipe variety: AI returned no menu plan response ID")
 	}
 	g.writeStatus(ctx, hash, menuPlan.String())
 
@@ -243,7 +217,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		ctx, span := tracer.Start(ctx, "recipes.generate.single")
 		defer span.End()
 		recipeInstructions := append([]string{p.Directive}, plan.Instructions()...)
-		recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, recipeInstructions, *recipeContext)
+		recipe, err := g.aiClient.GenerateRecipe(ctx, recipeInstructions, menuResponseID)
 		if err != nil {
 			return nil, err
 		}
@@ -268,7 +242,17 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 
 func (g *generatorService) replacementMenuPlan(ctx context.Context, p *generatorParams, instructions []string, count int) (*ai.MenuPlan, error) {
 	if strings.TrimSpace(p.PreviousMenuPlanResponseID) != "" {
-		return g.aiClient.RegenerateMenuPlan(ctx, instructions, p.PreviousMenuPlanResponseID, count)
+		plan, err := g.aiClient.RegenerateMenuPlan(ctx, instructions, p.PreviousMenuPlanResponseID, count)
+		if err != nil {
+			return nil, err
+		}
+		if plan == nil {
+			return nil, fmt.Errorf("AI returned no menu plan")
+		}
+		if len(plan.Plans) == 0 {
+			return nil, fmt.Errorf("planned 0 replacement recipes")
+		}
+		return plan, nil
 	}
 	return nil, fmt.Errorf("missing previous menu plan response ID for menu date %s", p.Date.Format("2006-01-02"))
 }

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -25,6 +25,8 @@ const IngredientGradeCutoff = 6
 type aiClient interface {
 	CreateMenuPlan(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, count int) (*ai.MenuPlan, error)
 	RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error)
+	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error)
+	GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error)
 	GenerateRecipe(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.Recipe, error)
 	Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
@@ -141,21 +143,6 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			return nil, fmt.Errorf("failed to plan recipe replacements: planned %d replacements for %d dismissed recipes", len(menuPlan.Plans), len(p.Dismissed))
 		}
 		// does it matter how we associate these?
-		type plannedRegeneration struct {
-			plan       ai.RecipePlan
-			responseID string
-		}
-		var replacements []plannedRegeneration
-		for i, plan := range menuPlan.Plans {
-			if strings.TrimSpace(p.Dismissed[i].ResponseID) == "" {
-				return nil, fmt.Errorf("recipe %q is missing response ID for regeneration", p.Dismissed[i].Title)
-			}
-			replacements = append(replacements, plannedRegeneration{
-				plan:       plan,
-				responseID: p.Dismissed[i].ResponseID,
-			})
-		}
-
 		g.writeStatus(ctx, hash, menuPlan.String())
 
 		// this SHOULD hit the cache and we could do it in parallel with menu planning
@@ -169,12 +156,17 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		})
 		ingMap := inputIngredientMap(ingredients)
 
-		results, err := parallelism.MapWithErrors(replacements, func(replacement plannedRegeneration) (*ai.Recipe, error) {
+		contextID, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare recipe context: %w", err)
+		}
+
+		results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 			ctx, span := tracer.Start(ctx, "recipes.regenerate.single")
 			defer span.End()
 
-			instructions := append(slices.Clone(regenInstructions), replacement.plan.Instructions()...)
-			recipe, err := g.aiClient.Regenerate(ctx, instructions, replacement.responseID)
+			instructions := append(slices.Clone(regenInstructions), plan.Instructions()...)
+			recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, instructions, contextID)
 			if err != nil {
 				return nil, err
 			}
@@ -225,11 +217,16 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 	}
 	g.writeStatus(ctx, hash, menuPlan.String())
 
+	contextID, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare recipe context: %w", err)
+	}
+
 	results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 		ctx, span := tracer.Start(ctx, "recipes.generate.single")
 		defer span.End()
 		recipeInstructions := append(slices.Clone(recipeBaseInstructions), plan.Instructions()...)
-		recipe, err := g.aiClient.GenerateRecipe(ctx, p.Location, ingredients, recipeInstructions, p.Date, p.LastRecipes)
+		recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, recipeInstructions, contextID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -25,8 +25,8 @@ const IngredientGradeCutoff = 6
 type aiClient interface {
 	CreateMenuPlan(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, count int) (*ai.MenuPlan, error)
 	RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error)
-	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error)
-	GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error)
+	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error)
+	GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error)
 	Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
 	PickWine(ctx context.Context, recipe ai.Recipe, wines []ai.InputIngredient) (*ai.WineSelection, error)
@@ -39,6 +39,14 @@ type staplesService interface {
 
 type recipeSaver interface {
 	SaveRecipe(ctx context.Context, recipes ai.Recipe) error
+}
+
+func recipePromptCacheKey(ingredientHash string) string {
+	ingredientHash = strings.TrimSpace(ingredientHash)
+	if ingredientHash == "" {
+		return ""
+	}
+	return "ingredients-" + ingredientHash
 }
 
 type generatorService struct {
@@ -147,8 +155,8 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			err  error
 		}
 		type asyncContextResult struct {
-			id  string
-			err error
+			context *ai.RecipeContext
+			err     error
 		}
 		menuPlanCh := make(chan asyncMenuPlanResult, 1)
 		contextCh := make(chan asyncContextResult, 1)
@@ -156,9 +164,10 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			plan, err := g.replacementMenuPlan(ctx, p, regenInstructions, len(p.Dismissed))
 			menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 		}()
+		recipeCacheKey := recipePromptCacheKey(p.LocationHash())
 		go func() {
-			id, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes)
-			contextCh <- asyncContextResult{id: id, err: err}
+			recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes, recipeCacheKey)
+			contextCh <- asyncContextResult{context: recipeContext, err: err}
 		}()
 
 		menuPlanResult := <-menuPlanCh
@@ -170,7 +179,10 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			return nil, fmt.Errorf("failed to prepare recipe context: %w", contextResult.err)
 		}
 		menuPlan := menuPlanResult.plan
-		contextID := contextResult.id
+		recipeContext := contextResult.context
+		if recipeContext == nil {
+			return nil, fmt.Errorf("failed to prepare recipe context: AI returned no recipe context")
+		}
 		if menuPlan == nil {
 			return nil, fmt.Errorf("failed to plan recipe replacements: AI returned no menu plan")
 		}
@@ -184,7 +196,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			defer span.End()
 
 			instructions := append(slices.Clone(regenInstructions), plan.Instructions()...)
-			recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, instructions, contextID)
+			recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, instructions, *recipeContext)
 			if err != nil {
 				return nil, err
 			}
@@ -234,8 +246,8 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		err  error
 	}
 	type asyncContextResult struct {
-		id  string
-		err error
+		context *ai.RecipeContext
+		err     error
 	}
 	menuPlanCh := make(chan asyncMenuPlanResult, 1)
 	contextCh := make(chan asyncContextResult, 1)
@@ -243,9 +255,10 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		plan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, 3)
 		menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 	}()
+	recipeCacheKey := recipePromptCacheKey(p.LocationHash())
 	go func() {
-		id, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes)
-		contextCh <- asyncContextResult{id: id, err: err}
+		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes, recipeCacheKey)
+		contextCh <- asyncContextResult{context: recipeContext, err: err}
 	}()
 
 	menuPlanResult := <-menuPlanCh
@@ -257,14 +270,17 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		return nil, fmt.Errorf("failed to prepare recipe context: %w", contextResult.err)
 	}
 	menuPlan := menuPlanResult.plan
-	contextID := contextResult.id
+	recipeContext := contextResult.context
+	if recipeContext == nil {
+		return nil, fmt.Errorf("failed to prepare recipe context: AI returned no recipe context")
+	}
 	g.writeStatus(ctx, hash, menuPlan.String())
 
 	results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 		ctx, span := tracer.Start(ctx, "recipes.generate.single")
 		defer span.End()
 		recipeInstructions := append(slices.Clone(recipeBaseInstructions), plan.Instructions()...)
-		recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, recipeInstructions, contextID)
+		recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, recipeInstructions, *recipeContext)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -25,7 +25,7 @@ const IngredientGradeCutoff = 6
 type aiClient interface {
 	CreateMenuPlan(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, count int) (*ai.MenuPlan, error)
 	RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error)
-	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error)
+	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error)
 	GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error)
 	Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
@@ -39,14 +39,6 @@ type staplesService interface {
 
 type recipeSaver interface {
 	SaveRecipe(ctx context.Context, recipes ai.Recipe) error
-}
-
-func recipePromptCacheKey(ingredientHash string) string {
-	ingredientHash = strings.TrimSpace(ingredientHash)
-	if ingredientHash == "" {
-		return ""
-	}
-	return "ingredients-" + ingredientHash
 }
 
 type generatorService struct {
@@ -164,9 +156,8 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 			plan, err := g.replacementMenuPlan(ctx, p, regenInstructions, len(p.Dismissed))
 			menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 		}()
-		recipeCacheKey := recipePromptCacheKey(p.LocationHash())
 		go func() {
-			recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes, recipeCacheKey)
+			recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes)
 			contextCh <- asyncContextResult{context: recipeContext, err: err}
 		}()
 
@@ -255,9 +246,8 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		plan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, 3)
 		menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 	}()
-	recipeCacheKey := recipePromptCacheKey(p.LocationHash())
 	go func() {
-		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes, recipeCacheKey)
+		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes)
 		contextCh <- asyncContextResult{context: recipeContext, err: err}
 	}()
 

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -27,7 +27,6 @@ type aiClient interface {
 	RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error)
 	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error)
 	GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error)
-	GenerateRecipe(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.Recipe, error)
 	Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
 	PickWine(ctx context.Context, recipe ai.Recipe, wines []ai.InputIngredient) (*ai.WineSelection, error)
@@ -132,19 +131,6 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 
 		regenInstructions := regenerateInstructions(p)
 
-		menuPlan, err := g.replacementMenuPlan(ctx, p, regenInstructions, len(p.Dismissed))
-		if err != nil {
-			return nil, fmt.Errorf("failed to plan recipe replacements: %w", err)
-		}
-		if menuPlan == nil {
-			return nil, fmt.Errorf("failed to plan recipe replacements: AI returned no menu plan")
-		}
-		if len(menuPlan.Plans) != len(p.Dismissed) {
-			return nil, fmt.Errorf("failed to plan recipe replacements: planned %d replacements for %d dismissed recipes", len(menuPlan.Plans), len(p.Dismissed))
-		}
-		// does it matter how we associate these?
-		g.writeStatus(ctx, hash, menuPlan.String())
-
 		// this SHOULD hit the cache and we could do it in parallel with menu planning
 		ingredients, err := g.staples.FetchStaples(ctx, p)
 		if err != nil {
@@ -156,10 +142,42 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		})
 		ingMap := inputIngredientMap(ingredients)
 
-		contextID, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to prepare recipe context: %w", err)
+		type asyncMenuPlanResult struct {
+			plan *ai.MenuPlan
+			err  error
 		}
+		type asyncContextResult struct {
+			id  string
+			err error
+		}
+		menuPlanCh := make(chan asyncMenuPlanResult, 1)
+		contextCh := make(chan asyncContextResult, 1)
+		go func() {
+			plan, err := g.replacementMenuPlan(ctx, p, regenInstructions, len(p.Dismissed))
+			menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
+		}()
+		go func() {
+			id, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes)
+			contextCh <- asyncContextResult{id: id, err: err}
+		}()
+
+		menuPlanResult := <-menuPlanCh
+		contextResult := <-contextCh
+		if menuPlanResult.err != nil {
+			return nil, fmt.Errorf("failed to plan recipe replacements: %w", menuPlanResult.err)
+		}
+		if contextResult.err != nil {
+			return nil, fmt.Errorf("failed to prepare recipe context: %w", contextResult.err)
+		}
+		menuPlan := menuPlanResult.plan
+		contextID := contextResult.id
+		if menuPlan == nil {
+			return nil, fmt.Errorf("failed to plan recipe replacements: AI returned no menu plan")
+		}
+		if len(menuPlan.Plans) != len(p.Dismissed) {
+			return nil, fmt.Errorf("failed to plan recipe replacements: planned %d replacements for %d dismissed recipes", len(menuPlan.Plans), len(p.Dismissed))
+		}
+		g.writeStatus(ctx, hash, menuPlan.String())
 
 		results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 			ctx, span := tracer.Start(ctx, "recipes.regenerate.single")
@@ -211,16 +229,36 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 	menuPlanInstructions := []string{p.Directive, p.Instructions}
 	recipeBaseInstructions := []string{p.Directive}
 
-	menuPlan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, 3)
-	if err != nil {
-		return nil, fmt.Errorf("failed to plan recipe variety: %w", err)
+	type asyncMenuPlanResult struct {
+		plan *ai.MenuPlan
+		err  error
 	}
-	g.writeStatus(ctx, hash, menuPlan.String())
+	type asyncContextResult struct {
+		id  string
+		err error
+	}
+	menuPlanCh := make(chan asyncMenuPlanResult, 1)
+	contextCh := make(chan asyncContextResult, 1)
+	go func() {
+		plan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, 3)
+		menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
+	}()
+	go func() {
+		id, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes)
+		contextCh <- asyncContextResult{id: id, err: err}
+	}()
 
-	contextID, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare recipe context: %w", err)
+	menuPlanResult := <-menuPlanCh
+	contextResult := <-contextCh
+	if menuPlanResult.err != nil {
+		return nil, fmt.Errorf("failed to plan recipe variety: %w", menuPlanResult.err)
 	}
+	if contextResult.err != nil {
+		return nil, fmt.Errorf("failed to prepare recipe context: %w", contextResult.err)
+	}
+	menuPlan := menuPlanResult.plan
+	contextID := contextResult.id
+	g.writeStatus(ctx, hash, menuPlan.String())
 
 	results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 		ctx, span := tracer.Start(ctx, "recipes.generate.single")

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -25,7 +25,8 @@ const IngredientGradeCutoff = 6
 type aiClient interface {
 	CreateMenuPlan(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, count int) (*ai.MenuPlan, error)
 	RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error)
-	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error)
+	// should last recipes just be sent to menuplan?
+	PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time) (*ai.RecipeContext, error)
 	GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error)
 	Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
@@ -142,52 +143,24 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		})
 		ingMap := inputIngredientMap(ingredients)
 
-		type asyncMenuPlanResult struct {
-			plan *ai.MenuPlan
-			err  error
+		plan, err := g.replacementMenuPlan(ctx, p, regenInstructions, len(p.Dismissed))
+		if err != nil {
+			return nil, fmt.Errorf("failed to plan recipe replacements: %w", err)
 		}
-		type asyncContextResult struct {
-			context *ai.RecipeContext
-			err     error
-		}
-		menuPlanCh := make(chan asyncMenuPlanResult, 1)
-		contextCh := make(chan asyncContextResult, 1)
-		go func() {
-			plan, err := g.replacementMenuPlan(ctx, p, regenInstructions, len(p.Dismissed))
-			menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
-		}()
-		go func() {
-			recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, []string{p.Directive}, p.Date, p.LastRecipes)
-			contextCh <- asyncContextResult{context: recipeContext, err: err}
-		}()
+		g.writeStatus(ctx, hash, plan.String())
 
-		menuPlanResult := <-menuPlanCh
-		contextResult := <-contextCh
-		if menuPlanResult.err != nil {
-			return nil, fmt.Errorf("failed to plan recipe replacements: %w", menuPlanResult.err)
+		// better to save the intiial recipe context like we save PreviousMenuPlanResponseID
+		rctx := ai.RecipeContext{
+			ResponseID: p.Dismissed[0].ResponseID,
 		}
-		if contextResult.err != nil {
-			return nil, fmt.Errorf("failed to prepare recipe context: %w", contextResult.err)
-		}
-		menuPlan := menuPlanResult.plan
-		recipeContext := contextResult.context
-		if recipeContext == nil {
-			return nil, fmt.Errorf("failed to prepare recipe context: AI returned no recipe context")
-		}
-		if menuPlan == nil {
-			return nil, fmt.Errorf("failed to plan recipe replacements: AI returned no menu plan")
-		}
-		if len(menuPlan.Plans) != len(p.Dismissed) {
-			return nil, fmt.Errorf("failed to plan recipe replacements: planned %d replacements for %d dismissed recipes", len(menuPlan.Plans), len(p.Dismissed))
-		}
-		g.writeStatus(ctx, hash, menuPlan.String())
 
-		results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
+		results, err := parallelism.MapWithErrors(plan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 			ctx, span := tracer.Start(ctx, "recipes.regenerate.single")
 			defer span.End()
 
+			// start fresh here?
 			instructions := append(slices.Clone(regenInstructions), plan.Instructions()...)
-			recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, instructions, *recipeContext)
+			recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, instructions, rctx)
 			if err != nil {
 				return nil, err
 			}
@@ -207,7 +180,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		slog.InfoContext(ctx, "regenerated chat", "location", p.String(), "duration", time.Since(start), "hash", hash)
 		return &ai.ShoppingList{
 			Recipes: recipes,
-			Plan:    menuPlan,
+			Plan:    plan, // should we append to last plan? only saved ones?
 		}, nil
 	}
 
@@ -230,7 +203,6 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 	mutable.Shuffle(ingredients)
 
 	menuPlanInstructions := []string{p.Directive, p.Instructions}
-	recipeBaseInstructions := []string{p.Directive}
 
 	type asyncMenuPlanResult struct {
 		plan *ai.MenuPlan
@@ -247,7 +219,8 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		menuPlanCh <- asyncMenuPlanResult{plan: plan, err: err}
 	}()
 	go func() {
-		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, recipeBaseInstructions, p.Date, p.LastRecipes)
+		// not clear this gets us any extra caching. Does it get us speed?
+		recipeContext, err := g.aiClient.PrepareRecipeContext(ctx, p.Location, ingredients, p.Date)
 		contextCh <- asyncContextResult{context: recipeContext, err: err}
 	}()
 
@@ -269,7 +242,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 	results, err := parallelism.MapWithErrors(menuPlan.Plans, func(plan ai.RecipePlan) (*ai.Recipe, error) {
 		ctx, span := tracer.Start(ctx, "recipes.generate.single")
 		defer span.End()
-		recipeInstructions := append(slices.Clone(recipeBaseInstructions), plan.Instructions()...)
+		recipeInstructions := append([]string{p.Directive}, plan.Instructions()...)
 		recipe, err := g.aiClient.GenerateRecipeFromContext(ctx, recipeInstructions, *recipeContext)
 		if err != nil {
 			return nil, err
@@ -297,24 +270,7 @@ func (g *generatorService) replacementMenuPlan(ctx context.Context, p *generator
 	if strings.TrimSpace(p.PreviousMenuPlanResponseID) != "" {
 		return g.aiClient.RegenerateMenuPlan(ctx, instructions, p.PreviousMenuPlanResponseID, count)
 	}
-	if p.Date.After(menuPlanResponseIDBackCompatLastDate) {
-		return nil, fmt.Errorf("missing previous menu plan response ID for menu date %s", p.Date.Format("2006-01-02"))
-	}
-	// Backward compatibility for cached shopping lists created before menu plan response IDs were persisted.
-	slog.WarnContext(ctx, "no menuplan on regen")
-	return backCompatMenuPlan(count), nil
-}
-
-func backCompatMenuPlan(count int) *ai.MenuPlan {
-	plans := make([]ai.RecipePlan, 0, count)
-	for range count {
-		plans = append(plans, ai.RecipePlan{
-			Cuisine:          "anything",
-			AnchorIngredient: "anything",
-			Technique:        "anything",
-		})
-	}
-	return &ai.MenuPlan{Plans: plans}
+	return nil, fmt.Errorf("missing previous menu plan response ID for menu date %s", p.Date.Format("2006-01-02"))
 }
 
 // generator not prociding a lot of value here. Should sever just hold an ai client?

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -30,6 +30,7 @@ type captureRegenerateAIClient struct {
 	responseID                 string
 	preparedContextID          string
 	contextInstructions        []string
+	contextPromptCacheKey      string
 	generateContextID          string
 	recipe                     *ai.Recipe
 	menuPlanInstructions       []string
@@ -41,16 +42,17 @@ type captureRegenerateAIClient struct {
 }
 
 type captureGenerateAIClient struct {
-	shoppingList         *ai.ShoppingList
-	menuPlan             *ai.MenuPlan
-	preparedContextID    string
-	contextInstructions  []string
-	generateContextIDs   []string
-	ingredients          []ai.InputIngredient
-	instructions         [][]string
-	generateInstructions [][]string
-	lastRecipes          []string
-	mu                   sync.Mutex
+	shoppingList          *ai.ShoppingList
+	menuPlan              *ai.MenuPlan
+	preparedContextID     string
+	contextInstructions   []string
+	contextPromptCacheKey string
+	generateContextIDs    []string
+	ingredients           []ai.InputIngredient
+	instructions          [][]string
+	generateInstructions  [][]string
+	lastRecipes           []string
+	mu                    sync.Mutex
 }
 
 type sequenceAIClient struct {
@@ -63,6 +65,7 @@ type sequenceAIClient struct {
 	regenerateCalls        int
 	prepareContextCalls    int
 	contextInstructions    [][]string
+	contextPromptCacheKeys []string
 	generateContextIDs     []string
 	regenerateInstructions [][]string
 	regenerateResponseIDs  []string
@@ -128,11 +131,11 @@ func (c *captureWineQuestionAIClient) RegenerateMenuPlan(ctx context.Context, in
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
+func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error) {
 	panic("unexpected call to PrepareRecipeContext")
 }
 
-func (c *captureWineQuestionAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+func (c *captureWineQuestionAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
 	panic("unexpected call to GenerateRecipeFromContext")
 }
 
@@ -183,17 +186,18 @@ func (c *captureRegenerateAIClient) RegenerateMenuPlan(ctx context.Context, inst
 	return &ai.MenuPlan{}, nil
 }
 
-func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
+func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error) {
 	c.contextInstructions = append([]string(nil), instructions...)
+	c.contextPromptCacheKey = promptCacheKey
 	if c.preparedContextID != "" {
-		return c.preparedContextID, nil
+		return &ai.RecipeContext{ResponseID: c.preparedContextID, PromptCacheKey: promptCacheKey}, nil
 	}
-	return "resp-shared-context", nil
+	return &ai.RecipeContext{ResponseID: "resp-shared-context", PromptCacheKey: promptCacheKey}, nil
 }
 
-func (c *captureRegenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+func (c *captureRegenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
 	c.instructions = append([]string(nil), instructions...)
-	c.generateContextID = previousResponseID
+	c.generateContextID = recipeContext.ResponseID
 	if c.recipe != nil {
 		return c.recipe, nil
 	}
@@ -245,22 +249,23 @@ func (c *captureGenerateAIClient) RegenerateMenuPlan(ctx context.Context, instru
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
+func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.contextInstructions = append([]string(nil), instructions...)
+	c.contextPromptCacheKey = promptCacheKey
 	if c.preparedContextID != "" {
-		return c.preparedContextID, nil
+		return &ai.RecipeContext{ResponseID: c.preparedContextID, PromptCacheKey: promptCacheKey}, nil
 	}
-	return "resp-shared-context", nil
+	return &ai.RecipeContext{ResponseID: "resp-shared-context", PromptCacheKey: promptCacheKey}, nil
 }
 
-func (c *captureGenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+func (c *captureGenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.generateContextIDs = append(c.generateContextIDs, previousResponseID)
+	c.generateContextIDs = append(c.generateContextIDs, recipeContext.ResponseID)
 	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
 	if c.shoppingList == nil {
 		return &ai.Recipe{}, nil
@@ -332,20 +337,21 @@ func (c *sequenceAIClient) RegenerateMenuPlan(ctx context.Context, instructions 
 	return menuPlanForRecipes(resp.Recipes), nil
 }
 
-func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
+func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.prepareContextCalls++
 	c.contextInstructions = append(c.contextInstructions, append([]string(nil), instructions...))
-	return "resp-shared-context", nil
+	c.contextPromptCacheKeys = append(c.contextPromptCacheKeys, promptCacheKey)
+	return &ai.RecipeContext{ResponseID: "resp-shared-context", PromptCacheKey: promptCacheKey}, nil
 }
 
-func (c *sequenceAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+func (c *sequenceAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.generateContextIDs = append(c.generateContextIDs, previousResponseID)
+	c.generateContextIDs = append(c.generateContextIDs, recipeContext.ResponseID)
 	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
 	for _, recipe := range c.plannedRecipes {
 		if recipeInstructionsContainAnchor(instructions, recipe.Title) {
@@ -669,6 +675,9 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	}
 	if !slices.Equal(aiStub.contextInstructions, []string{"Use the store's sale ingredients."}) {
 		t.Fatalf("unexpected context instructions: got %v", aiStub.contextInstructions)
+	}
+	if got, want := aiStub.contextPromptCacheKey, recipePromptCacheKey(params.LocationHash()); got != want {
+		t.Fatalf("unexpected prompt cache key: got %q want %q", got, want)
 	}
 	if aiStub.menuPlanResponseID != "resp-menu-old" {
 		t.Fatalf("expected menu plan response ID %q, got %q", "resp-menu-old", aiStub.menuPlanResponseID)

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -606,9 +606,10 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	aiStub := &captureRegenerateAIClient{
 		recipe: &newResult,
 		menuPlan: &ai.MenuPlan{Plans: []ai.RecipePlan{{
-			Cuisine:          "test",
-			AnchorIngredient: "Brand New Dinner",
-			Technique:        "test",
+			Cuisine:            "test",
+			AnchorIngredient:   "Brand New Dinner",
+			Technique:          "test",
+			RecipeInstructions: []string{"make it vegetarian"},
 		}}, ResponseID: "resp-menu-next"},
 	}
 	cacheStore := cache.NewFileCache(t.TempDir())
@@ -631,21 +632,22 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 		t.Fatalf("GenerateRecipes returned error: %v", err)
 	}
 
-	wantInstructions := []string{
+	wantMenuPlanInstructions := []string{
 		"make it vegetarian",
 		"Enjoyed and saved so don't repeat: Newly Saved",
 		"Passed on Dismissed Recipe",
 	}
-	wantRecipeInstructions := append(slices.Clone(wantInstructions), ai.RecipePlan{
-		Cuisine:          "test",
-		AnchorIngredient: "Brand New Dinner",
-		Technique:        "test",
-	}.Instructions()...)
+	wantRecipeInstructions := ai.RecipePlan{
+		Cuisine:            "test",
+		AnchorIngredient:   "Brand New Dinner",
+		Technique:          "test",
+		RecipeInstructions: []string{"make it vegetarian"},
+	}.Instructions()
 	if !slices.Equal(aiStub.instructions, wantRecipeInstructions) {
 		t.Fatalf("unexpected recipe instructions: got %v want %v", aiStub.instructions, wantRecipeInstructions)
 	}
-	if !slices.Equal(aiStub.menuPlanInstructions, wantInstructions) {
-		t.Fatalf("unexpected menu plan instructions: got %v want %v", aiStub.menuPlanInstructions, wantInstructions)
+	if !slices.Equal(aiStub.menuPlanInstructions, wantMenuPlanInstructions) {
+		t.Fatalf("unexpected menu plan instructions: got %v want %v", aiStub.menuPlanInstructions, wantMenuPlanInstructions)
 	}
 	if aiStub.generateMenuResponseID != "resp-menu-next" {
 		t.Fatalf("expected menu plan response ID %q, got %q", "resp-menu-next", aiStub.generateMenuResponseID)
@@ -719,7 +721,7 @@ func TestGenerateRecipes_RegenerateWithoutMenuPlanResponseIDErrors(t *testing.T)
 
 	g := newTestGenerator(t, aiStub, nil, seededStaples(t, params), noopstatuswriter{}, nil)
 	_, err := g.GenerateRecipes(t.Context(), params)
-	require.ErrorContains(t, err, "missing previous menu plan response ID for menu date 2026-05-22")
+	require.ErrorContains(t, err, "missing previous menu plan response ID for menu")
 
 	if aiStub.createMenuPlanCount != 0 || aiStub.menuPlanCount != 0 {
 		t.Fatalf("missing response ID should fail before menu planning calls, got create=%d regenerate=%d", aiStub.createMenuPlanCount, aiStub.menuPlanCount)

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -26,11 +26,10 @@ type captureWineQuestionAIClient struct {
 }
 
 type captureRegenerateAIClient struct {
+	mu                         sync.Mutex
 	instructions               []string
 	responseID                 string
-	preparedContextID          string
-	contextInstructions        []string
-	generateContextID          string
+	generateMenuResponseID     string
 	recipe                     *ai.Recipe
 	menuPlanInstructions       []string
 	menuPlanResponseID         string
@@ -41,35 +40,31 @@ type captureRegenerateAIClient struct {
 }
 
 type captureGenerateAIClient struct {
-	shoppingList         *ai.ShoppingList
-	menuPlan             *ai.MenuPlan
-	preparedContextID    string
-	contextInstructions  []string
-	generateContextIDs   []string
-	ingredients          []ai.InputIngredient
-	instructions         [][]string
-	generateInstructions [][]string
-	lastRecipes          []string
-	mu                   sync.Mutex
+	shoppingList            *ai.ShoppingList
+	menuPlan                *ai.MenuPlan
+	generateMenuResponseIDs []string
+	ingredients             []ai.InputIngredient
+	instructions            [][]string
+	generateInstructions    [][]string
+	lastRecipes             []string
+	mu                      sync.Mutex
 }
 
 type sequenceAIClient struct {
-	mu                     sync.Mutex
-	generateCalls          int
-	generateInstructions   [][]string
-	menuPlanInstructions   [][]string
-	menuPlanResponseIDs    []string
-	menuPlanCounts         []int
-	regenerateCalls        int
-	prepareContextCalls    int
-	contextInstructions    [][]string
-	generateContextIDs     []string
-	regenerateInstructions [][]string
-	regenerateResponseIDs  []string
-	generateResponses      []*ai.ShoppingList
-	menuPlanResponses      []*ai.MenuPlan
-	plannedRecipes         []ai.Recipe
-	regenerateResponses    []*ai.Recipe
+	mu                      sync.Mutex
+	generateCalls           int
+	generateInstructions    [][]string
+	menuPlanInstructions    [][]string
+	menuPlanResponseIDs     []string
+	menuPlanCounts          []int
+	regenerateCalls         int
+	generateMenuResponseIDs []string
+	regenerateInstructions  [][]string
+	regenerateResponseIDs   []string
+	generateResponses       []*ai.ShoppingList
+	menuPlanResponses       []*ai.MenuPlan
+	plannedRecipes          []ai.Recipe
+	regenerateResponses     []*ai.Recipe
 }
 
 type captureCritiqueService struct {
@@ -128,12 +123,8 @@ func (c *captureWineQuestionAIClient) RegenerateMenuPlan(ctx context.Context, in
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
-	panic("unexpected call to PrepareRecipeContext")
-}
-
-func (c *captureWineQuestionAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
-	panic("unexpected call to GenerateRecipeFromContext")
+func (c *captureWineQuestionAIClient) GenerateRecipe(ctx context.Context, instructions []string, menuResponseID string) (*ai.Recipe, error) {
+	panic("unexpected call to GenerateRecipe")
 }
 
 func (c *captureWineQuestionAIClient) Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error) {
@@ -165,46 +156,58 @@ func (c *captureWineQuestionAIClient) Ready(ctx context.Context) error {
 }
 
 func (c *captureRegenerateAIClient) CreateMenuPlan(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, count int) (*ai.MenuPlan, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.createMenuPlanInstructions = append([]string(nil), instructions...)
 	c.createMenuPlanCount = count
 	if c.menuPlan != nil {
+		if c.menuPlan.ResponseID == "" {
+			c.menuPlan.ResponseID = "resp-menu-next"
+		}
 		return c.menuPlan, nil
 	}
-	return &ai.MenuPlan{}, nil
+	return &ai.MenuPlan{ResponseID: "resp-menu-next"}, nil
 }
 
 func (c *captureRegenerateAIClient) RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.menuPlanInstructions = append([]string(nil), instructions...)
 	c.menuPlanResponseID = previousResponseID
 	c.menuPlanCount = count
 	if c.menuPlan != nil {
+		if c.menuPlan.ResponseID == "" {
+			c.menuPlan.ResponseID = "resp-menu-next"
+		}
 		return c.menuPlan, nil
 	}
-	return &ai.MenuPlan{}, nil
+	return &ai.MenuPlan{ResponseID: "resp-menu-next"}, nil
 }
 
-func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
-	c.contextInstructions = append([]string(nil), instructions...)
-	if c.preparedContextID != "" {
-		return &ai.RecipeContext{ResponseID: c.preparedContextID}, nil
-	}
-	return &ai.RecipeContext{ResponseID: "resp-shared-context"}, nil
-}
+func (c *captureRegenerateAIClient) GenerateRecipe(ctx context.Context, instructions []string, menuResponseID string) (*ai.Recipe, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-func (c *captureRegenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
 	c.instructions = append([]string(nil), instructions...)
-	c.generateContextID = recipeContext.ResponseID
+	c.generateMenuResponseID = menuResponseID
 	if c.recipe != nil {
-		return c.recipe, nil
+		recipe := *c.recipe
+		return &recipe, nil
 	}
 	return &ai.Recipe{}, nil
 }
 
 func (c *captureRegenerateAIClient) Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.instructions = append([]string(nil), newinstructions...)
 	c.responseID = previousResponseID
 	if c.recipe != nil {
-		return c.recipe, nil
+		recipe := *c.recipe
+		return &recipe, nil
 	}
 	return &ai.Recipe{}, nil
 }
@@ -245,22 +248,11 @@ func (c *captureGenerateAIClient) RegenerateMenuPlan(ctx context.Context, instru
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *captureGenerateAIClient) GenerateRecipe(ctx context.Context, instructions []string, menuResponseID string) (*ai.Recipe, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.contextInstructions = append([]string(nil), instructions...)
-	if c.preparedContextID != "" {
-		return &ai.RecipeContext{ResponseID: c.preparedContextID}, nil
-	}
-	return &ai.RecipeContext{ResponseID: "resp-shared-context"}, nil
-}
-
-func (c *captureGenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.generateContextIDs = append(c.generateContextIDs, recipeContext.ResponseID)
+	c.generateMenuResponseIDs = append(c.generateMenuResponseIDs, menuResponseID)
 	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
 	if c.shoppingList == nil {
 		return &ai.Recipe{}, nil
@@ -332,20 +324,11 @@ func (c *sequenceAIClient) RegenerateMenuPlan(ctx context.Context, instructions 
 	return menuPlanForRecipes(resp.Recipes), nil
 }
 
-func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *sequenceAIClient) GenerateRecipe(ctx context.Context, instructions []string, menuResponseID string) (*ai.Recipe, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.prepareContextCalls++
-	c.contextInstructions = append(c.contextInstructions, append([]string(nil), instructions...))
-	return &ai.RecipeContext{ResponseID: "resp-shared-context"}, nil
-}
-
-func (c *sequenceAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.generateContextIDs = append(c.generateContextIDs, recipeContext.ResponseID)
+	c.generateMenuResponseIDs = append(c.generateMenuResponseIDs, menuResponseID)
 	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
 	for _, recipe := range c.plannedRecipes {
 		if recipeInstructionsContainAnchor(instructions, recipe.Title) {
@@ -408,7 +391,7 @@ func menuPlanForRecipes(recipes []ai.Recipe) *ai.MenuPlan {
 			Technique:        "test",
 		})
 	}
-	return &ai.MenuPlan{Plans: plans}
+	return &ai.MenuPlan{Plans: plans, ResponseID: "resp-menu-plan"}
 }
 
 func (c *sequenceAIClient) AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error) {
@@ -664,11 +647,8 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	if !slices.Equal(aiStub.menuPlanInstructions, wantInstructions) {
 		t.Fatalf("unexpected menu plan instructions: got %v want %v", aiStub.menuPlanInstructions, wantInstructions)
 	}
-	if aiStub.generateContextID != "resp-shared-context" {
-		t.Fatalf("expected shared recipe context ID %q, got %q", "resp-shared-context", aiStub.generateContextID)
-	}
-	if !slices.Equal(aiStub.contextInstructions, []string{"Use the store's sale ingredients."}) {
-		t.Fatalf("unexpected context instructions: got %v", aiStub.contextInstructions)
+	if aiStub.generateMenuResponseID != "resp-menu-next" {
+		t.Fatalf("expected menu plan response ID %q, got %q", "resp-menu-next", aiStub.generateMenuResponseID)
 	}
 	if aiStub.menuPlanResponseID != "resp-menu-old" {
 		t.Fatalf("expected menu plan response ID %q, got %q", "resp-menu-old", aiStub.menuPlanResponseID)
@@ -684,7 +664,7 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	}
 }
 
-func TestGenerateRecipes_RegeneratePlanCountMismatchReturnsHelpfulError(t *testing.T) {
+func TestGenerateRecipes_RegenerateNoReplacementPlansReturnsHelpfulError(t *testing.T) {
 	dismissed := ai.Recipe{Title: "Dismissed Recipe", Description: "Passed on", ResponseID: "resp-123"}
 	aiStub := &captureRegenerateAIClient{
 		menuPlan: &ai.MenuPlan{Plans: []ai.RecipePlan{}, ResponseID: "resp-menu-next"},
@@ -697,11 +677,35 @@ func TestGenerateRecipes_RegeneratePlanCountMismatchReturnsHelpfulError(t *testi
 
 	g := newTestGenerator(t, aiStub, nil, seededStaples(t, params), noopstatuswriter{}, nil)
 	_, err := g.GenerateRecipes(t.Context(), params)
-	require.ErrorContains(t, err, "failed to plan recipe replacements: planned 0 replacements for 1 dismissed recipes")
+	require.ErrorContains(t, err, "failed to plan recipe replacements: planned 0 replacement recipes")
 	require.NotContains(t, err.Error(), "%!w(<nil>)")
 }
 
-func TestGenerateRecipes_RegenerateBackCompatFallbackUsesFakePlan(t *testing.T) {
+func TestGenerateRecipes_RegenerateAllowsUserRequestedCountDifferentFromDismissedCount(t *testing.T) {
+	dismissed := ai.Recipe{Title: "Dismissed Recipe", Description: "Passed on", ResponseID: "resp-123"}
+	newResult := ai.Recipe{Title: "Brand New Dinner", Description: "Fresh idea", ResponseID: "resp-new"}
+	aiStub := &captureRegenerateAIClient{
+		recipe: &newResult,
+		menuPlan: &ai.MenuPlan{Plans: []ai.RecipePlan{
+			{Cuisine: "test", AnchorIngredient: "Slow Cooker Dinner", Technique: "slow cooker"},
+			{Cuisine: "test", AnchorIngredient: "Different Pasta", Technique: "pasta"},
+		}, ResponseID: "resp-menu-next"},
+	}
+
+	params := DefaultParams(&locations.Location{ID: "70004001", Name: "Store"}, time.Now())
+	params.Instructions = "give me two more recipes, a slow cooker recipe and a different pasta"
+	params.Dismissed = []ai.Recipe{dismissed}
+	params.PreviousMenuPlanResponseID = "resp-menu-old"
+
+	g := newTestGenerator(t, aiStub, nil, seededStaples(t, params), noopstatuswriter{}, nil)
+	got, err := g.GenerateRecipes(t.Context(), params)
+	require.NoError(t, err)
+	require.Len(t, got.Recipes, 2)
+	require.Equal(t, 1, aiStub.menuPlanCount)
+	require.Equal(t, "resp-menu-next", aiStub.generateMenuResponseID)
+}
+
+func TestGenerateRecipes_RegenerateWithoutMenuPlanResponseIDErrors(t *testing.T) {
 	dismissed := ai.Recipe{Title: "Dismissed Recipe", Description: "Passed on", ResponseID: "resp-123"}
 	newResult := ai.Recipe{Title: "Brand New Dinner", Description: "Fresh idea", ResponseID: "resp-new"}
 	aiStub := &captureRegenerateAIClient{
@@ -715,43 +719,7 @@ func TestGenerateRecipes_RegenerateBackCompatFallbackUsesFakePlan(t *testing.T) 
 
 	g := newTestGenerator(t, aiStub, nil, seededStaples(t, params), noopstatuswriter{}, nil)
 	_, err := g.GenerateRecipes(t.Context(), params)
-	require.NoError(t, err)
-
-	wantInstructions := []string{
-		"make it brighter",
-		"Passed on Dismissed Recipe",
-	}
-	if aiStub.createMenuPlanCount != 0 || len(aiStub.createMenuPlanInstructions) != 0 {
-		t.Fatalf("back-compat fallback should not create a fresh menu plan, got count=%d instructions=%v", aiStub.createMenuPlanCount, aiStub.createMenuPlanInstructions)
-	}
-	if aiStub.menuPlanCount != 0 || len(aiStub.menuPlanInstructions) != 0 {
-		t.Fatalf("back-compat fallback should not regenerate a menu plan, got count=%d instructions=%v", aiStub.menuPlanCount, aiStub.menuPlanInstructions)
-	}
-	wantRecipeInstructions := append(slices.Clone(wantInstructions), ai.RecipePlan{
-		Cuisine:          "anything",
-		AnchorIngredient: "anything",
-		Technique:        "anything",
-	}.Instructions()...)
-	if !slices.Equal(aiStub.instructions, wantRecipeInstructions) {
-		t.Fatalf("unexpected fallback recipe instructions: got %v want %v", aiStub.instructions, wantRecipeInstructions)
-	}
-}
-
-func TestGenerateRecipes_RegenerateBackCompatFallbackErrorsAfterCutoff(t *testing.T) {
-	dismissed := ai.Recipe{Title: "Dismissed Recipe", Description: "Passed on", ResponseID: "resp-123"}
-	newResult := ai.Recipe{Title: "Brand New Dinner", Description: "Fresh idea", ResponseID: "resp-new"}
-	aiStub := &captureRegenerateAIClient{
-		recipe: &newResult,
-	}
-
-	params := DefaultParams(&locations.Location{ID: "70004001", Name: "Store"}, time.Date(2026, time.May, 25, 0, 0, 0, 0, time.UTC))
-	params.Directive = "Use the store's sale ingredients."
-	params.Instructions = "make it brighter"
-	params.Dismissed = []ai.Recipe{dismissed}
-
-	g := newTestGenerator(t, aiStub, nil, seededStaples(t, params), noopstatuswriter{}, nil)
-	_, err := g.GenerateRecipes(t.Context(), params)
-	require.ErrorContains(t, err, "missing previous menu plan response ID for menu date 2026-05-25")
+	require.ErrorContains(t, err, "missing previous menu plan response ID for menu date 2026-05-22")
 
 	if aiStub.createMenuPlanCount != 0 || aiStub.menuPlanCount != 0 {
 		t.Fatalf("missing response ID should fail before menu planning calls, got create=%d regenerate=%d", aiStub.createMenuPlanCount, aiStub.menuPlanCount)
@@ -787,7 +755,7 @@ func TestGenerateRecipes_UsesMenuPlanRecipeInstructionsInsteadOfSendingUserDirec
 		menuPlan: &ai.MenuPlan{Plans: []ai.RecipePlan{
 			{Cuisine: "test", AnchorIngredient: aniseRecipe.Title, Technique: "test", RecipeInstructions: []string{"Use the user's anise in this recipe."}},
 			{Cuisine: "test", AnchorIngredient: plainRecipe.Title, Technique: "test"},
-		}},
+		}, ResponseID: "resp-menu-plan"},
 	}
 	g := newTestGenerator(t, aiStub, nil, seededStaples(t, params), noopstatuswriter{}, nil)
 
@@ -1234,8 +1202,8 @@ func TestGenerateRecipes_RegenerateRetriesLowScoringRecipesOnce(t *testing.T) {
 	if aiStub.regenerateCalls != 1 {
 		t.Fatalf("expected one critique retry, got %d calls", aiStub.regenerateCalls)
 	}
-	if got := aiStub.generateContextIDs; !slices.Equal(got, []string{"resp-shared-context"}) {
-		t.Fatalf("unexpected replacement context IDs: got %v", got)
+	if got := aiStub.generateMenuResponseIDs; !slices.Equal(got, []string{"resp-menu-plan"}) {
+		t.Fatalf("unexpected replacement menu response IDs: got %v", got)
 	}
 	if got := aiStub.regenerateResponseIDs; !slices.Equal(got, []string{"resp-first-pass"}) {
 		t.Fatalf("unexpected regenerate response IDs: got %v", got)

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -29,7 +29,6 @@ type captureRegenerateAIClient struct {
 	instructions               []string
 	responseID                 string
 	preparedContextID          string
-	contextInstructions        []string
 	generateContextID          string
 	recipe                     *ai.Recipe
 	menuPlanInstructions       []string
@@ -44,7 +43,6 @@ type captureGenerateAIClient struct {
 	shoppingList         *ai.ShoppingList
 	menuPlan             *ai.MenuPlan
 	preparedContextID    string
-	contextInstructions  []string
 	generateContextIDs   []string
 	ingredients          []ai.InputIngredient
 	instructions         [][]string
@@ -62,7 +60,6 @@ type sequenceAIClient struct {
 	menuPlanCounts         []int
 	regenerateCalls        int
 	prepareContextCalls    int
-	contextInstructions    [][]string
 	generateContextIDs     []string
 	regenerateInstructions [][]string
 	regenerateResponseIDs  []string
@@ -128,7 +125,7 @@ func (c *captureWineQuestionAIClient) RegenerateMenuPlan(ctx context.Context, in
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	panic("unexpected call to PrepareRecipeContext")
 }
 
@@ -183,8 +180,7 @@ func (c *captureRegenerateAIClient) RegenerateMenuPlan(ctx context.Context, inst
 	return &ai.MenuPlan{}, nil
 }
 
-func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
-	c.contextInstructions = append([]string(nil), instructions...)
+func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	if c.preparedContextID != "" {
 		return &ai.RecipeContext{ResponseID: c.preparedContextID}, nil
 	}
@@ -245,11 +241,10 @@ func (c *captureGenerateAIClient) RegenerateMenuPlan(ctx context.Context, instru
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.contextInstructions = append([]string(nil), instructions...)
 	if c.preparedContextID != "" {
 		return &ai.RecipeContext{ResponseID: c.preparedContextID}, nil
 	}
@@ -332,12 +327,11 @@ func (c *sequenceAIClient) RegenerateMenuPlan(ctx context.Context, instructions 
 	return menuPlanForRecipes(resp.Recipes), nil
 }
 
-func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.prepareContextCalls++
-	c.contextInstructions = append(c.contextInstructions, append([]string(nil), instructions...))
 	return &ai.RecipeContext{ResponseID: "resp-shared-context"}, nil
 }
 
@@ -666,9 +660,6 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	}
 	if aiStub.generateContextID != "resp-shared-context" {
 		t.Fatalf("expected shared recipe context ID %q, got %q", "resp-shared-context", aiStub.generateContextID)
-	}
-	if !slices.Equal(aiStub.contextInstructions, []string{"Use the store's sale ingredients."}) {
-		t.Fatalf("unexpected context instructions: got %v", aiStub.contextInstructions)
 	}
 	if aiStub.menuPlanResponseID != "resp-menu-old" {
 		t.Fatalf("expected menu plan response ID %q, got %q", "resp-menu-old", aiStub.menuPlanResponseID)

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -29,6 +29,7 @@ type captureRegenerateAIClient struct {
 	instructions               []string
 	responseID                 string
 	preparedContextID          string
+	contextInstructions        []string
 	generateContextID          string
 	recipe                     *ai.Recipe
 	menuPlanInstructions       []string
@@ -43,6 +44,7 @@ type captureGenerateAIClient struct {
 	shoppingList         *ai.ShoppingList
 	menuPlan             *ai.MenuPlan
 	preparedContextID    string
+	contextInstructions  []string
 	generateContextIDs   []string
 	ingredients          []ai.InputIngredient
 	instructions         [][]string
@@ -60,6 +62,7 @@ type sequenceAIClient struct {
 	menuPlanCounts         []int
 	regenerateCalls        int
 	prepareContextCalls    int
+	contextInstructions    [][]string
 	generateContextIDs     []string
 	regenerateInstructions [][]string
 	regenerateResponseIDs  []string
@@ -125,7 +128,7 @@ func (c *captureWineQuestionAIClient) RegenerateMenuPlan(ctx context.Context, in
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	panic("unexpected call to PrepareRecipeContext")
 }
 
@@ -180,7 +183,8 @@ func (c *captureRegenerateAIClient) RegenerateMenuPlan(ctx context.Context, inst
 	return &ai.MenuPlan{}, nil
 }
 
-func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+	c.contextInstructions = append([]string(nil), instructions...)
 	if c.preparedContextID != "" {
 		return &ai.RecipeContext{ResponseID: c.preparedContextID}, nil
 	}
@@ -241,10 +245,11 @@ func (c *captureGenerateAIClient) RegenerateMenuPlan(ctx context.Context, instru
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.contextInstructions = append([]string(nil), instructions...)
 	if c.preparedContextID != "" {
 		return &ai.RecipeContext{ResponseID: c.preparedContextID}, nil
 	}
@@ -327,11 +332,12 @@ func (c *sequenceAIClient) RegenerateMenuPlan(ctx context.Context, instructions 
 	return menuPlanForRecipes(resp.Recipes), nil
 }
 
-func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
+func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.prepareContextCalls++
+	c.contextInstructions = append(c.contextInstructions, append([]string(nil), instructions...))
 	return &ai.RecipeContext{ResponseID: "resp-shared-context"}, nil
 }
 
@@ -660,6 +666,9 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	}
 	if aiStub.generateContextID != "resp-shared-context" {
 		t.Fatalf("expected shared recipe context ID %q, got %q", "resp-shared-context", aiStub.generateContextID)
+	}
+	if !slices.Equal(aiStub.contextInstructions, []string{"Use the store's sale ingredients."}) {
+		t.Fatalf("unexpected context instructions: got %v", aiStub.contextInstructions)
 	}
 	if aiStub.menuPlanResponseID != "resp-menu-old" {
 		t.Fatalf("expected menu plan response ID %q, got %q", "resp-menu-old", aiStub.menuPlanResponseID)

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -30,7 +30,6 @@ type captureRegenerateAIClient struct {
 	responseID                 string
 	preparedContextID          string
 	contextInstructions        []string
-	contextPromptCacheKey      string
 	generateContextID          string
 	recipe                     *ai.Recipe
 	menuPlanInstructions       []string
@@ -42,17 +41,16 @@ type captureRegenerateAIClient struct {
 }
 
 type captureGenerateAIClient struct {
-	shoppingList          *ai.ShoppingList
-	menuPlan              *ai.MenuPlan
-	preparedContextID     string
-	contextInstructions   []string
-	contextPromptCacheKey string
-	generateContextIDs    []string
-	ingredients           []ai.InputIngredient
-	instructions          [][]string
-	generateInstructions  [][]string
-	lastRecipes           []string
-	mu                    sync.Mutex
+	shoppingList         *ai.ShoppingList
+	menuPlan             *ai.MenuPlan
+	preparedContextID    string
+	contextInstructions  []string
+	generateContextIDs   []string
+	ingredients          []ai.InputIngredient
+	instructions         [][]string
+	generateInstructions [][]string
+	lastRecipes          []string
+	mu                   sync.Mutex
 }
 
 type sequenceAIClient struct {
@@ -65,7 +63,6 @@ type sequenceAIClient struct {
 	regenerateCalls        int
 	prepareContextCalls    int
 	contextInstructions    [][]string
-	contextPromptCacheKeys []string
 	generateContextIDs     []string
 	regenerateInstructions [][]string
 	regenerateResponseIDs  []string
@@ -131,7 +128,7 @@ func (c *captureWineQuestionAIClient) RegenerateMenuPlan(ctx context.Context, in
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error) {
+func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	panic("unexpected call to PrepareRecipeContext")
 }
 
@@ -186,13 +183,12 @@ func (c *captureRegenerateAIClient) RegenerateMenuPlan(ctx context.Context, inst
 	return &ai.MenuPlan{}, nil
 }
 
-func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error) {
+func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	c.contextInstructions = append([]string(nil), instructions...)
-	c.contextPromptCacheKey = promptCacheKey
 	if c.preparedContextID != "" {
-		return &ai.RecipeContext{ResponseID: c.preparedContextID, PromptCacheKey: promptCacheKey}, nil
+		return &ai.RecipeContext{ResponseID: c.preparedContextID}, nil
 	}
-	return &ai.RecipeContext{ResponseID: "resp-shared-context", PromptCacheKey: promptCacheKey}, nil
+	return &ai.RecipeContext{ResponseID: "resp-shared-context"}, nil
 }
 
 func (c *captureRegenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
@@ -249,16 +245,15 @@ func (c *captureGenerateAIClient) RegenerateMenuPlan(ctx context.Context, instru
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error) {
+func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.contextInstructions = append([]string(nil), instructions...)
-	c.contextPromptCacheKey = promptCacheKey
 	if c.preparedContextID != "" {
-		return &ai.RecipeContext{ResponseID: c.preparedContextID, PromptCacheKey: promptCacheKey}, nil
+		return &ai.RecipeContext{ResponseID: c.preparedContextID}, nil
 	}
-	return &ai.RecipeContext{ResponseID: "resp-shared-context", PromptCacheKey: promptCacheKey}, nil
+	return &ai.RecipeContext{ResponseID: "resp-shared-context"}, nil
 }
 
 func (c *captureGenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
@@ -337,14 +332,13 @@ func (c *sequenceAIClient) RegenerateMenuPlan(ctx context.Context, instructions 
 	return menuPlanForRecipes(resp.Recipes), nil
 }
 
-func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string, promptCacheKey string) (*ai.RecipeContext, error) {
+func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.RecipeContext, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.prepareContextCalls++
 	c.contextInstructions = append(c.contextInstructions, append([]string(nil), instructions...))
-	c.contextPromptCacheKeys = append(c.contextPromptCacheKeys, promptCacheKey)
-	return &ai.RecipeContext{ResponseID: "resp-shared-context", PromptCacheKey: promptCacheKey}, nil
+	return &ai.RecipeContext{ResponseID: "resp-shared-context"}, nil
 }
 
 func (c *sequenceAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
@@ -675,9 +669,6 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	}
 	if !slices.Equal(aiStub.contextInstructions, []string{"Use the store's sale ingredients."}) {
 		t.Fatalf("unexpected context instructions: got %v", aiStub.contextInstructions)
-	}
-	if got, want := aiStub.contextPromptCacheKey, recipePromptCacheKey(params.LocationHash()); got != want {
-		t.Fatalf("unexpected prompt cache key: got %q want %q", got, want)
 	}
 	if aiStub.menuPlanResponseID != "resp-menu-old" {
 		t.Fatalf("expected menu plan response ID %q, got %q", "resp-menu-old", aiStub.menuPlanResponseID)

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -28,6 +28,9 @@ type captureWineQuestionAIClient struct {
 type captureRegenerateAIClient struct {
 	instructions               []string
 	responseID                 string
+	preparedContextID          string
+	contextInstructions        []string
+	generateContextID          string
 	recipe                     *ai.Recipe
 	menuPlanInstructions       []string
 	menuPlanResponseID         string
@@ -40,6 +43,9 @@ type captureRegenerateAIClient struct {
 type captureGenerateAIClient struct {
 	shoppingList         *ai.ShoppingList
 	menuPlan             *ai.MenuPlan
+	preparedContextID    string
+	contextInstructions  []string
+	generateContextIDs   []string
 	ingredients          []ai.InputIngredient
 	instructions         [][]string
 	generateInstructions [][]string
@@ -55,6 +61,9 @@ type sequenceAIClient struct {
 	menuPlanResponseIDs    []string
 	menuPlanCounts         []int
 	regenerateCalls        int
+	prepareContextCalls    int
+	contextInstructions    [][]string
+	generateContextIDs     []string
 	regenerateInstructions [][]string
 	regenerateResponseIDs  []string
 	generateResponses      []*ai.ShoppingList
@@ -123,6 +132,14 @@ func (c *captureWineQuestionAIClient) GenerateRecipe(ctx context.Context, locati
 	panic("unexpected call to GenerateRecipe")
 }
 
+func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
+	panic("unexpected call to PrepareRecipeContext")
+}
+
+func (c *captureWineQuestionAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	panic("unexpected call to GenerateRecipeFromContext")
+}
+
 func (c *captureWineQuestionAIClient) Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error) {
 	panic("unexpected call to Regenerate")
 }
@@ -178,6 +195,23 @@ func (c *captureRegenerateAIClient) GenerateRecipe(ctx context.Context, location
 	return &ai.Recipe{}, nil
 }
 
+func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
+	c.contextInstructions = append([]string(nil), instructions...)
+	if c.preparedContextID != "" {
+		return c.preparedContextID, nil
+	}
+	return "resp-shared-context", nil
+}
+
+func (c *captureRegenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	c.instructions = append([]string(nil), instructions...)
+	c.generateContextID = previousResponseID
+	if c.recipe != nil {
+		return c.recipe, nil
+	}
+	return &ai.Recipe{}, nil
+}
+
 func (c *captureRegenerateAIClient) Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error) {
 	c.instructions = append([]string(nil), newinstructions...)
 	c.responseID = previousResponseID
@@ -227,6 +261,34 @@ func (c *captureGenerateAIClient) GenerateRecipe(ctx context.Context, location *
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
+	if c.shoppingList == nil {
+		return &ai.Recipe{}, nil
+	}
+	for _, recipe := range c.shoppingList.Recipes {
+		if recipeInstructionsContainAnchor(instructions, recipe.Title) {
+			return &recipe, nil
+		}
+	}
+	return &ai.Recipe{}, nil
+}
+
+func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.contextInstructions = append([]string(nil), instructions...)
+	if c.preparedContextID != "" {
+		return c.preparedContextID, nil
+	}
+	return "resp-shared-context", nil
+}
+
+func (c *captureGenerateAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.generateContextIDs = append(c.generateContextIDs, previousResponseID)
 	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
 	if c.shoppingList == nil {
 		return &ai.Recipe{}, nil
@@ -302,6 +364,29 @@ func (c *sequenceAIClient) GenerateRecipe(ctx context.Context, location *locatio
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
+	for _, recipe := range c.plannedRecipes {
+		if recipeInstructionsContainAnchor(instructions, recipe.Title) {
+			return &recipe, nil
+		}
+	}
+	return &ai.Recipe{}, nil
+}
+
+func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.prepareContextCalls++
+	c.contextInstructions = append(c.contextInstructions, append([]string(nil), instructions...))
+	return "resp-shared-context", nil
+}
+
+func (c *sequenceAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.generateContextIDs = append(c.generateContextIDs, previousResponseID)
 	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
 	for _, recipe := range c.plannedRecipes {
 		if recipeInstructionsContainAnchor(instructions, recipe.Title) {
@@ -620,8 +705,11 @@ func TestGenerateRecipes_RegenerateIncludesOnlyNewlySavedRecipesInAvoidInstructi
 	if !slices.Equal(aiStub.menuPlanInstructions, wantInstructions) {
 		t.Fatalf("unexpected menu plan instructions: got %v want %v", aiStub.menuPlanInstructions, wantInstructions)
 	}
-	if aiStub.responseID != "resp-123" {
-		t.Fatalf("expected recipe response ID %q, got %q", "resp-123", aiStub.responseID)
+	if aiStub.generateContextID != "resp-shared-context" {
+		t.Fatalf("expected shared recipe context ID %q, got %q", "resp-shared-context", aiStub.generateContextID)
+	}
+	if !slices.Equal(aiStub.contextInstructions, []string{"Use the store's sale ingredients."}) {
+		t.Fatalf("unexpected context instructions: got %v", aiStub.contextInstructions)
 	}
 	if aiStub.menuPlanResponseID != "resp-menu-old" {
 		t.Fatalf("expected menu plan response ID %q, got %q", "resp-menu-old", aiStub.menuPlanResponseID)
@@ -1134,10 +1222,7 @@ func TestGenerateRecipes_RegenerateRetriesLowScoringRecipesOnce(t *testing.T) {
 		generateResponses: []*ai.ShoppingList{{
 			Recipes: []ai.Recipe{initial},
 		}},
-		regenerateResponses: []*ai.Recipe{
-			&initial,
-			&retried,
-		},
+		regenerateResponses: []*ai.Recipe{&retried},
 	}
 	critiquer := &captureCritiqueService{
 		fn: func(recipe ai.Recipe) (*ai.RecipeCritique, error) {
@@ -1187,17 +1272,20 @@ func TestGenerateRecipes_RegenerateRetriesLowScoringRecipesOnce(t *testing.T) {
 	if got := aiStub.menuPlanCounts; !slices.Equal(got, []int{1}) {
 		t.Fatalf("unexpected menu plan counts: got %v", got)
 	}
-	if aiStub.regenerateCalls != 2 {
-		t.Fatalf("expected initial replacement plus one critique retry, got %d calls", aiStub.regenerateCalls)
+	if aiStub.regenerateCalls != 1 {
+		t.Fatalf("expected one critique retry, got %d calls", aiStub.regenerateCalls)
 	}
-	if got := aiStub.regenerateResponseIDs; !slices.Equal(got, []string{"resp-original", "resp-first-pass"}) {
+	if got := aiStub.generateContextIDs; !slices.Equal(got, []string{"resp-shared-context"}) {
+		t.Fatalf("unexpected replacement context IDs: got %v", got)
+	}
+	if got := aiStub.regenerateResponseIDs; !slices.Equal(got, []string{"resp-first-pass"}) {
 		t.Fatalf("unexpected regenerate response IDs: got %v", got)
 	}
 	wantRetryInstructions := []string{
 		"Revise recipe. Description should focus on selling the dish not these corrections.",
 		"scored 5/10.\n Issues: [timing/medium] Cooking times are inconsistent.\n Suggested fixes: make the timing consistent",
 	}
-	if got := aiStub.regenerateInstructions[1]; !slices.Equal(got, wantRetryInstructions) {
+	if got := aiStub.regenerateInstructions[0]; !slices.Equal(got, wantRetryInstructions) {
 		t.Fatalf("unexpected critique retry instructions: got %v want %v", got, wantRetryInstructions)
 	}
 }
@@ -1216,10 +1304,7 @@ func TestGenerateRecipes_CritiqueRetryPointsToImmediateParent(t *testing.T) {
 		generateResponses: []*ai.ShoppingList{{
 			Recipes: []ai.Recipe{firstPass},
 		}},
-		regenerateResponses: []*ai.Recipe{
-			&firstPass,
-			&retried,
-		},
+		regenerateResponses: []*ai.Recipe{&retried},
 	}
 	critiquer := &captureCritiqueService{
 		fn: func(recipe ai.Recipe) (*ai.RecipeCritique, error) {

--- a/internal/recipes/generator_test.go
+++ b/internal/recipes/generator_test.go
@@ -128,10 +128,6 @@ func (c *captureWineQuestionAIClient) RegenerateMenuPlan(ctx context.Context, in
 	panic("unexpected call to RegenerateMenuPlan")
 }
 
-func (c *captureWineQuestionAIClient) GenerateRecipe(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.Recipe, error) {
-	panic("unexpected call to GenerateRecipe")
-}
-
 func (c *captureWineQuestionAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
 	panic("unexpected call to PrepareRecipeContext")
 }
@@ -185,14 +181,6 @@ func (c *captureRegenerateAIClient) RegenerateMenuPlan(ctx context.Context, inst
 		return c.menuPlan, nil
 	}
 	return &ai.MenuPlan{}, nil
-}
-
-func (c *captureRegenerateAIClient) GenerateRecipe(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.Recipe, error) {
-	c.instructions = append([]string(nil), instructions...)
-	if c.recipe != nil {
-		return c.recipe, nil
-	}
-	return &ai.Recipe{}, nil
 }
 
 func (c *captureRegenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
@@ -255,22 +243,6 @@ func (c *captureGenerateAIClient) CreateMenuPlan(ctx context.Context, location *
 
 func (c *captureGenerateAIClient) RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*ai.MenuPlan, error) {
 	panic("unexpected call to RegenerateMenuPlan")
-}
-
-func (c *captureGenerateAIClient) GenerateRecipe(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.Recipe, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
-	if c.shoppingList == nil {
-		return &ai.Recipe{}, nil
-	}
-	for _, recipe := range c.shoppingList.Recipes {
-		if recipeInstructionsContainAnchor(instructions, recipe.Title) {
-			return &recipe, nil
-		}
-	}
-	return &ai.Recipe{}, nil
 }
 
 func (c *captureGenerateAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {
@@ -358,19 +330,6 @@ func (c *sequenceAIClient) RegenerateMenuPlan(ctx context.Context, instructions 
 	c.generateResponses = c.generateResponses[1:]
 	c.plannedRecipes = slices.Clone(resp.Recipes)
 	return menuPlanForRecipes(resp.Recipes), nil
-}
-
-func (c *sequenceAIClient) GenerateRecipe(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (*ai.Recipe, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.generateInstructions = append(c.generateInstructions, append([]string(nil), instructions...))
-	for _, recipe := range c.plannedRecipes {
-		if recipeInstructionsContainAnchor(instructions, recipe.Title) {
-			return &recipe, nil
-		}
-	}
-	return &ai.Recipe{}, nil
 }
 
 func (c *sequenceAIClient) PrepareRecipeContext(ctx context.Context, location *locations.Location, ingredients []ai.InputIngredient, instructions []string, date time.Time, lastRecipes []string) (string, error) {

--- a/internal/recipes/tracing_ai_client.go
+++ b/internal/recipes/tracing_ai_client.go
@@ -39,20 +39,6 @@ func (c *tracingAIClient) RegenerateMenuPlan(ctx context.Context, instructions [
 	return c.next.RegenerateMenuPlan(ctx, instructions, previousResponseID, count)
 }
 
-func (c *tracingAIClient) GenerateRecipe(
-	ctx context.Context,
-	location *locations.Location,
-	ingredients []ai.InputIngredient,
-	instructions []string,
-	date time.Time,
-	lastRecipes []string,
-) (*ai.Recipe, error) {
-	ctx, span := tracer.Start(ctx, "recipes.ai.generate_recipe")
-	defer span.End()
-
-	return c.next.GenerateRecipe(ctx, location, ingredients, instructions, date, lastRecipes)
-}
-
 func (c *tracingAIClient) PrepareRecipeContext(
 	ctx context.Context,
 	location *locations.Location,

--- a/internal/recipes/tracing_ai_client.go
+++ b/internal/recipes/tracing_ai_client.go
@@ -53,6 +53,27 @@ func (c *tracingAIClient) GenerateRecipe(
 	return c.next.GenerateRecipe(ctx, location, ingredients, instructions, date, lastRecipes)
 }
 
+func (c *tracingAIClient) PrepareRecipeContext(
+	ctx context.Context,
+	location *locations.Location,
+	ingredients []ai.InputIngredient,
+	instructions []string,
+	date time.Time,
+	lastRecipes []string,
+) (string, error) {
+	ctx, span := tracer.Start(ctx, "recipes.ai.prepare_recipe_context")
+	defer span.End()
+
+	return c.next.PrepareRecipeContext(ctx, location, ingredients, instructions, date, lastRecipes)
+}
+
+func (c *tracingAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	ctx, span := tracer.Start(ctx, "recipes.ai.generate_recipe_from_context")
+	defer span.End()
+
+	return c.next.GenerateRecipeFromContext(ctx, instructions, previousResponseID)
+}
+
 func (c *tracingAIClient) Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error) {
 	ctx, span := tracer.Start(ctx, "recipes.ai.regenerate")
 	defer span.End()

--- a/internal/recipes/tracing_ai_client.go
+++ b/internal/recipes/tracing_ai_client.go
@@ -43,14 +43,13 @@ func (c *tracingAIClient) PrepareRecipeContext(
 	ctx context.Context,
 	location *locations.Location,
 	ingredients []ai.InputIngredient,
-	instructions []string,
 	date time.Time,
 	lastRecipes []string,
 ) (*ai.RecipeContext, error) {
 	ctx, span := tracer.Start(ctx, "recipes.ai.prepare_recipe_context")
 	defer span.End()
 
-	return c.next.PrepareRecipeContext(ctx, location, ingredients, instructions, date, lastRecipes)
+	return c.next.PrepareRecipeContext(ctx, location, ingredients, date, lastRecipes)
 }
 
 func (c *tracingAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {

--- a/internal/recipes/tracing_ai_client.go
+++ b/internal/recipes/tracing_ai_client.go
@@ -46,18 +46,19 @@ func (c *tracingAIClient) PrepareRecipeContext(
 	instructions []string,
 	date time.Time,
 	lastRecipes []string,
-) (string, error) {
+	promptCacheKey string,
+) (*ai.RecipeContext, error) {
 	ctx, span := tracer.Start(ctx, "recipes.ai.prepare_recipe_context")
 	defer span.End()
 
-	return c.next.PrepareRecipeContext(ctx, location, ingredients, instructions, date, lastRecipes)
+	return c.next.PrepareRecipeContext(ctx, location, ingredients, instructions, date, lastRecipes, promptCacheKey)
 }
 
-func (c *tracingAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+func (c *tracingAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
 	ctx, span := tracer.Start(ctx, "recipes.ai.generate_recipe_from_context")
 	defer span.End()
 
-	return c.next.GenerateRecipeFromContext(ctx, instructions, previousResponseID)
+	return c.next.GenerateRecipeFromContext(ctx, instructions, recipeContext)
 }
 
 func (c *tracingAIClient) Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error) {

--- a/internal/recipes/tracing_ai_client.go
+++ b/internal/recipes/tracing_ai_client.go
@@ -46,12 +46,11 @@ func (c *tracingAIClient) PrepareRecipeContext(
 	instructions []string,
 	date time.Time,
 	lastRecipes []string,
-	promptCacheKey string,
 ) (*ai.RecipeContext, error) {
 	ctx, span := tracer.Start(ctx, "recipes.ai.prepare_recipe_context")
 	defer span.End()
 
-	return c.next.PrepareRecipeContext(ctx, location, ingredients, instructions, date, lastRecipes, promptCacheKey)
+	return c.next.PrepareRecipeContext(ctx, location, ingredients, instructions, date, lastRecipes)
 }
 
 func (c *tracingAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {

--- a/internal/recipes/tracing_ai_client.go
+++ b/internal/recipes/tracing_ai_client.go
@@ -43,13 +43,14 @@ func (c *tracingAIClient) PrepareRecipeContext(
 	ctx context.Context,
 	location *locations.Location,
 	ingredients []ai.InputIngredient,
+	instructions []string,
 	date time.Time,
 	lastRecipes []string,
 ) (*ai.RecipeContext, error) {
 	ctx, span := tracer.Start(ctx, "recipes.ai.prepare_recipe_context")
 	defer span.End()
 
-	return c.next.PrepareRecipeContext(ctx, location, ingredients, date, lastRecipes)
+	return c.next.PrepareRecipeContext(ctx, location, ingredients, instructions, date, lastRecipes)
 }
 
 func (c *tracingAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {

--- a/internal/recipes/tracing_ai_client.go
+++ b/internal/recipes/tracing_ai_client.go
@@ -43,14 +43,12 @@ func (c *tracingAIClient) PrepareRecipeContext(
 	ctx context.Context,
 	location *locations.Location,
 	ingredients []ai.InputIngredient,
-	instructions []string,
 	date time.Time,
-	lastRecipes []string,
 ) (*ai.RecipeContext, error) {
 	ctx, span := tracer.Start(ctx, "recipes.ai.prepare_recipe_context")
 	defer span.End()
 
-	return c.next.PrepareRecipeContext(ctx, location, ingredients, instructions, date, lastRecipes)
+	return c.next.PrepareRecipeContext(ctx, location, ingredients, date)
 }
 
 func (c *tracingAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {

--- a/internal/recipes/tracing_ai_client.go
+++ b/internal/recipes/tracing_ai_client.go
@@ -39,23 +39,11 @@ func (c *tracingAIClient) RegenerateMenuPlan(ctx context.Context, instructions [
 	return c.next.RegenerateMenuPlan(ctx, instructions, previousResponseID, count)
 }
 
-func (c *tracingAIClient) PrepareRecipeContext(
-	ctx context.Context,
-	location *locations.Location,
-	ingredients []ai.InputIngredient,
-	date time.Time,
-) (*ai.RecipeContext, error) {
-	ctx, span := tracer.Start(ctx, "recipes.ai.prepare_recipe_context")
+func (c *tracingAIClient) GenerateRecipe(ctx context.Context, instructions []string, menuResponseID string) (*ai.Recipe, error) {
+	ctx, span := tracer.Start(ctx, "recipes.ai.generate_recipe")
 	defer span.End()
 
-	return c.next.PrepareRecipeContext(ctx, location, ingredients, date)
-}
-
-func (c *tracingAIClient) GenerateRecipeFromContext(ctx context.Context, instructions []string, recipeContext ai.RecipeContext) (*ai.Recipe, error) {
-	ctx, span := tracer.Start(ctx, "recipes.ai.generate_recipe_from_context")
-	defer span.End()
-
-	return c.next.GenerateRecipeFromContext(ctx, instructions, recipeContext)
+	return c.next.GenerateRecipe(ctx, instructions, menuResponseID)
 }
 
 func (c *tracingAIClient) Regenerate(ctx context.Context, newinstructions []string, previousResponseID string) (*ai.Recipe, error) {


### PR DESCRIPTION
Idea here is to burn less on input tokens and get faster responses but also let recipes share some other context with menu planning while being free from most of context of ther recipe writing. 