### PR TITLE
Replace direct Google Ads gtag with Google Tag Manager and dataLayer signup event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,6 @@
 - Keep commits scoped and reviewable; avoid mixing refactors with feature changes unless necessary.
 
 ## Security & Configuration Notes
-- Required env vars: `KROGER_CLIENT_ID`, `KROGER_CLIENT_SECRET`, `AI_API_KEY`; optional `GEMINI_API_KEY`, `GEMINI_CRITIQUE_MODEL`, `CLARITY_PROJECT_ID`, `GOOGLE_TAG_ID`, `GOOGLE_CONVERSION_LABEL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`. Azure Blob cache still uses `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_PRIMARY_ACCOUNT_KEY`. Grafana Cloud direct OTLP uses the standard upstream OpenTelemetry endpoint and headers env vars.
+- Required env vars: `KROGER_CLIENT_ID`, `KROGER_CLIENT_SECRET`, `AI_API_KEY`; optional `GEMINI_API_KEY`, `GEMINI_CRITIQUE_MODEL`, `CLARITY_PROJECT_ID`, `GOOGLE_TAG_MANAGER_ID`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`. Azure Blob cache still uses `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_PRIMARY_ACCOUNT_KEY`. Grafana Cloud direct OTLP uses the standard upstream OpenTelemetry endpoint and headers env vars.
 - Never commit secrets or generated recipe outputs. If testing against real APIs, use minimal scopes and rotate keys promptly.
 - Any handler that lets you see data from multiple users should go behind the /admin mux to secure it. 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ The application is configured via environment variables:
 - `GEMINI_API_KEY` - Gemini API key for cached recipe critique generation
 - `GEMINI_CRITIQUE_MODEL` - Gemini model for recipe critique (defaults to `gemini-2.5-flash`)
 - `CLARITY_PROJECT_ID` - Microsoft Clarity project ID for web analytics (optional)
-- `GOOGLE_TAG_ID` - Google Ads/gtag ID for web analytics (optional)
-- `GOOGLE_CONVERSION_LABEL` - Google Ads conversion label used on `/auth/establish?signup=true` (optional)
+- `GOOGLE_TAG_MANAGER_ID` - Google Tag Manager container ID for web analytics and ad conversion tags (optional); see `docs/gtm-ads.md` for conversion setup
 - `OTEL_EXPORTER_OTLP_ENDPOINT` - OTLP HTTP endpoint. For Grafana Cloud, use the endpoint from the OpenTelemetry connection tile.
 - `OTEL_EXPORTER_OTLP_HEADERS` - OTLP headers. For Grafana Cloud, use the generated `Authorization=Basic ...` header value from the OpenTelemetry connection tile.
 - `SENDGRID_API_KEY` - To allow sending weekly recipe lists via email

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -60,10 +60,8 @@ spec:
               value: "deployment.environment.name=production,k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.app=$(WORKLOAD_NAME)"
             - name: CLARITY_PROJECT_ID
               value: "td2gxd3sq9"
-            - name: GOOGLE_TAG_ID
-              value: "AW-17902827663"
-            - name: GOOGLE_CONVERSION_LABEL
-              value: "xDzACMu074AcEI_x3dhC"
+            - name: GOOGLE_TAG_MANAGER_ID
+              value: ""
             - name: ADMIN_EMAILS
               value: "paul.miller@gmail.com"
             - name: PUBLIC_ORIGIN

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -61,7 +61,7 @@ spec:
             - name: CLARITY_PROJECT_ID
               value: "td2gxd3sq9"
             - name: GOOGLE_TAG_MANAGER_ID
-              value: ""
+              value: "GTM-KP55TPW6"
             - name: ADMIN_EMAILS
               value: "paul.miller@gmail.com"
             - name: PUBLIC_ORIGIN

--- a/docs/gtm-ads.md
+++ b/docs/gtm-ads.md
@@ -1,0 +1,42 @@
+# Google Tag Manager ad conversion setup
+
+Careme loads a Google Tag Manager (GTM) web container when `GOOGLE_TAG_MANAGER_ID` is set. The app no longer sends Google Ads conversions directly with `gtag`; instead, it publishes neutral `dataLayer` events and expects GTM to fan those events out to ad platforms.
+
+## Container ID
+
+Set `GOOGLE_TAG_MANAGER_ID` to your GTM web container ID, for example `GTM-ABC1234`. Do not use a Google Ads ID like `AW-...` here; Google Ads conversion IDs and labels belong inside GTM tags.
+
+## Signup conversion event
+
+When `/auth/establish` detects a first-time user, the page pushes this event:
+
+```js
+window.dataLayer.push({
+  event: "signup_completed",
+  eventCallback: finishRedirect,
+  eventTimeout: 1500,
+});
+```
+
+Use a GTM custom event trigger named `signup_completed` for conversion tags.
+
+## Google Ads conversion tag
+
+In GTM, create a Google Ads conversion tag using the existing Google Ads conversion ID and label. Trigger it with the `signup_completed` custom event.
+
+## OpenAI / ChatGPT Ads pixel
+
+To keep application JavaScript small, install the OpenAI Ads Measurement Pixel inside GTM rather than in Careme templates:
+
+1. Create a Custom HTML tag in GTM for the OpenAI pixel installation snippet.
+2. Put the OpenAI Ads pixel ID from Ads Manager in that snippet.
+3. Fire the installation tag on the pages where conversions can happen, or on all pages if you want the pixel loaded broadly.
+4. Create a second Custom HTML tag triggered by `signup_completed` that calls the OpenAI standard event for registration completion:
+
+```js
+oaiq("measure", "registration_completed", {
+  type: "customer_action",
+});
+```
+
+The browser still executes OpenAI's JavaScript SDK, but it is served and managed through GTM rather than committed to the app.

--- a/docs/gtm-ads.md
+++ b/docs/gtm-ads.md
@@ -4,7 +4,7 @@ Careme loads a Google Tag Manager (GTM) web container when `GOOGLE_TAG_MANAGER_I
 
 ## Container ID
 
-Set `GOOGLE_TAG_MANAGER_ID` to your GTM web container ID, for example `GTM-ABC1234`. Do not use a Google Ads ID like `AW-...` here; Google Ads conversion IDs and labels belong inside GTM tags.
+Set `GOOGLE_TAG_MANAGER_ID` to your GTM web container ID, for example `GTM-KP55TPW6`. Do not use a Google Ads ID like `AW-...` here; Google Ads conversion IDs and labels belong inside GTM tags.
 
 ## Signup conversion event
 
@@ -18,7 +18,7 @@ window.dataLayer.push({
 });
 ```
 
-Use a GTM custom event trigger named `signup_completed` for conversion tags.
+The app renders both the GTM head script and the GTM `noscript` iframe fallback immediately after the opening `<body>` tag when this environment variable is set. Use a GTM custom event trigger named `signup_completed` for conversion tags.
 
 ## Google Ads conversion tag
 

--- a/internal/auth/clerk.go
+++ b/internal/auth/clerk.go
@@ -169,17 +169,15 @@ func (c *clerkClient) Register(mux routing.Registrar) {
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		data := struct {
-			PublishableKey      string
-			GoogleTagScript     template.HTML
-			GoogleConversionTag string
-			UserExistsURL       string
-			ReturnTo            string // read from a data- attribute in the template to avoid JS-string escaping concerns
+			PublishableKey  string
+			GoogleTagScript template.HTML
+			UserExistsURL   string
+			ReturnTo        string // read from a data- attribute in the template to avoid JS-string escaping concerns
 		}{
-			PublishableKey:      c.cfg.Clerk.PublishableKey,
-			GoogleTagScript:     templates.GoogleTagScript(),
-			GoogleConversionTag: templates.GoogleConversionTag(),
-			UserExistsURL:       "/user/exists",
-			ReturnTo:            returnToFromRequest(r),
+			PublishableKey:  c.cfg.Clerk.PublishableKey,
+			GoogleTagScript: templates.GoogleTagScript(),
+			UserExistsURL:   "/user/exists",
+			ReturnTo:        returnToFromRequest(r),
 		}
 		if err := templates.AuthEstablish.Execute(w, data); err != nil {
 			slog.ErrorContext(r.Context(), "auth establish template execute error", "error", err)

--- a/internal/recipes/html_test.go
+++ b/internal/recipes/html_test.go
@@ -273,6 +273,10 @@ func TestFormatShoppingListHTML_IncludesGoogleTagManagerScript(t *testing.T) {
 	if !bytes.Contains(w.Body.Bytes(), []byte("'GTM-ABC123'")) {
 		t.Error("HTML should contain Google Tag Manager ID")
 	}
+
+	if !bytes.Contains(w.Body.Bytes(), []byte("www.googletagmanager.com/ns.html?id=GTM-ABC123")) {
+		t.Error("HTML should contain Google Tag Manager noscript URL")
+	}
 }
 
 func TestFormatShoppingListHTML_NoGoogleTagWhenEmpty(t *testing.T) {

--- a/internal/recipes/html_test.go
+++ b/internal/recipes/html_test.go
@@ -254,40 +254,40 @@ func TestFormatShoppingListHTML_NoClarityWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestFormatShoppingListHTML_IncludesGoogleTagScript(t *testing.T) {
+func TestFormatShoppingListHTML_IncludesGoogleTagManagerScript(t *testing.T) {
 	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St"}
 	p := DefaultParams(&loc, time.Now())
 
-	prev := templates.GoogleTagID
+	prev := templates.GoogleTagManagerID
 	t.Cleanup(func() {
-		templates.GoogleTagID = prev
+		templates.GoogleTagManagerID = prev
 	})
-	templates.GoogleTagID = "AW-1234567890"
+	templates.GoogleTagManagerID = "GTM-ABC123"
 	w := httptest.NewRecorder()
 	formatShoppingListHTMLForTest(t.Context(), p, list, true, recipeSelection{}, w)
 	assertHTTPSuccess(t, w)
-	if !bytes.Contains(w.Body.Bytes(), []byte("www.googletagmanager.com/gtag/js?id=AW-1234567890")) {
-		t.Error("HTML should contain Google tag script URL")
+	if !bytes.Contains(w.Body.Bytes(), []byte("www.googletagmanager.com/gtm.js?id=")) {
+		t.Error("HTML should contain Google Tag Manager script URL")
 	}
 
-	if !bytes.Contains(w.Body.Bytes(), []byte("gtag('config', 'AW-1234567890');")) {
-		t.Error("HTML should contain Google tag ID")
+	if !bytes.Contains(w.Body.Bytes(), []byte("'GTM-ABC123'")) {
+		t.Error("HTML should contain Google Tag Manager ID")
 	}
 }
 
 func TestFormatShoppingListHTML_NoGoogleTagWhenEmpty(t *testing.T) {
 	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St"}
 	p := DefaultParams(&loc, time.Now())
-	prev := templates.GoogleTagID
+	prev := templates.GoogleTagManagerID
 	t.Cleanup(func() {
-		templates.GoogleTagID = prev
+		templates.GoogleTagManagerID = prev
 	})
-	templates.GoogleTagID = ""
+	templates.GoogleTagManagerID = ""
 	w := httptest.NewRecorder()
 	formatShoppingListHTMLForTest(t.Context(), p, list, true, recipeSelection{}, w)
 	assertHTTPSuccess(t, w)
 	if bytes.Contains(w.Body.Bytes(), []byte("googletagmanager.com")) {
-		t.Error("HTML should not contain Google tag script when tag ID is empty")
+		t.Error("HTML should not contain Google Tag Manager script when tag ID is empty")
 	}
 }
 

--- a/internal/templates/about.html
+++ b/internal/templates/about.html
@@ -15,6 +15,7 @@
   {{.GoogleTagScript}}
 </head>
 <body class="min-h-screen bg-gradient-to-b from-brand-50 to-white antialiased">
+  {{GoogleTagNoScript}}
   {{template "seasonal_background" .}}
   <main class="relative z-10 px-4 py-10">
     <section class="mx-auto w-full max-w-5xl">

--- a/internal/templates/auth_establish.html
+++ b/internal/templates/auth_establish.html
@@ -7,6 +7,7 @@
     {{.GoogleTagScript}}
   </head>
   <body>
+  {{GoogleTagNoScript}}
     <script
       crossorigin="anonymous"
       data-clerk-publishable-key="{{.PublishableKey}}"

--- a/internal/templates/auth_establish.html
+++ b/internal/templates/auth_establish.html
@@ -38,12 +38,11 @@
         };
 
         checkUserExists().then((payload) => {
-          if (!payload.exists &&
-              "{{.GoogleConversionTag}}" !== "" &&
-              typeof gtag === "function") {
-            gtag("event", "conversion", {
-              send_to: "{{.GoogleConversionTag}}",
-              event_callback: finishRedirect,
+          if (!payload.exists && Array.isArray(window.dataLayer)) {
+            window.dataLayer.push({
+              event: "signup_completed",
+              eventCallback: finishRedirect,
+              eventTimeout: 1500,
             });
             setTimeout(finishRedirect, 1500);
             return;

--- a/internal/templates/critique.html
+++ b/internal/templates/critique.html
@@ -11,6 +11,7 @@
   {{.GoogleTagScript}}
 </head>
 <body class="relative min-h-screen overflow-x-hidden bg-gradient-to-b from-brand-50/80 via-white to-brand-50/80 text-ink-700 antialiased">
+  {{GoogleTagNoScript}}
   {{template "seasonal_background" .}}
 
   <main class="relative z-10 px-4 py-8 sm:py-10">

--- a/internal/templates/home.html
+++ b/internal/templates/home.html
@@ -13,6 +13,7 @@
   <meta name='impact-site-verification' value='eee2b715-38ff-4749-8396-f05aa85220db'>
 </head>
 <body class="relative min-h-screen overflow-x-hidden bg-gradient-to-b from-brand-50/80 via-white to-brand-50/80 text-ink-700 antialiased">
+  {{GoogleTagNoScript}}
   {{template "seasonal_background" .}}
 
   <main class="relative z-10 px-4 py-8 sm:py-10">

--- a/internal/templates/locations.html
+++ b/internal/templates/locations.html
@@ -11,6 +11,7 @@
   {{.GoogleTagScript}}
 </head>
 <body class="min-h-screen bg-gradient-to-b from-brand-50 to-white antialiased">
+  {{GoogleTagNoScript}}
   {{template "seasonal_background" .}}
   <main class="relative z-10 px-4 py-10">
     <section class="mx-auto w-full max-w-3xl">

--- a/internal/templates/recipe.html
+++ b/internal/templates/recipe.html
@@ -27,6 +27,7 @@
   {{.GoogleTagScript}}
 </head>
 <body class="min-h-screen bg-gradient-to-b from-brand-50 to-white antialiased">
+  {{GoogleTagNoScript}}
   {{template "seasonal_background" .}}
   <main class="relative z-10 px-4 py-10">
     <section class="mx-auto w-full max-w-4xl space-y-8">

--- a/internal/templates/shoppinglist.html
+++ b/internal/templates/shoppinglist.html
@@ -27,6 +27,7 @@
   {{.GoogleTagScript}}
 </head>
 <body class="min-h-screen bg-gradient-to-b from-brand-50 to-white text-ink-700 antialiased">
+  {{GoogleTagNoScript}}
   {{template "seasonal_background" .}}
   <main class="relative z-10 px-4 py-10">
     <section class="mx-auto w-full max-w-5xl space-y-8">

--- a/internal/templates/spinner.html
+++ b/internal/templates/spinner.html
@@ -14,6 +14,7 @@
   {{.GoogleTagScript}}
 </head>
 <body class="min-h-screen overflow-hidden bg-gradient-to-b from-brand-50 to-white text-ink-700 antialiased">
+  {{GoogleTagNoScript}}
   {{template "seasonal_background" .}}
   <main class="relative z-10 grid min-h-screen place-items-center px-4" role="status" aria-live="polite">
     <section class="friendly-card w-full max-w-md border border-brand-100 bg-white/90 p-10 text-center shadow-xl">

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -41,6 +41,7 @@ func Init(config *config.Config, tailwindAssetPath string) error {
 			}
 			return "https://" + domain + "/npm/@clerk/ui@1/dist/ui.browser.js"
 		},
+		"GoogleTagNoScript": GoogleTagNoScript,
 		"PublicOrigin":      func() string { return config.ResolvedPublicOrigin() },
 		"SignInPath":        signInPath,
 		"TailwindAssetPath": func() string { return tailwindAssetPath },
@@ -119,13 +120,28 @@ func GoogleTagScript() template.HTML {
 		return ""
 	}
 
-	script := `<script>
+	script := `<!-- Google Tag Manager -->
+<script>
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','` + template.JSEscapeString(GoogleTagManagerID) + `');
-</script>`
+</script>
+<!-- End Google Tag Manager -->`
 
 	return template.HTML(script)
+}
+
+// GoogleTagNoScript generates the Google Tag Manager noscript fallback HTML.
+func GoogleTagNoScript() template.HTML {
+	if GoogleTagManagerID == "" {
+		return ""
+	}
+
+	iframe := `<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=` + template.HTMLEscapeString(GoogleTagManagerID) + `" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->`
+
+	return template.HTML(iframe)
 }

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -62,8 +62,7 @@ func Init(config *config.Config, tailwindAssetPath string) error {
 
 	// todo pull from config.
 	Clarityproject = os.Getenv("CLARITY_PROJECT_ID")
-	GoogleTagID = os.Getenv("GOOGLE_TAG_ID")
-	GoogleConversionLabel = os.Getenv("GOOGLE_CONVERSION_LABEL")
+	GoogleTagManagerID = os.Getenv("GOOGLE_TAG_MANAGER_ID")
 	return nil
 }
 
@@ -85,9 +84,8 @@ func signInPath(returnTo string) string {
 }
 
 var (
-	Clarityproject        string
-	GoogleTagID           string
-	GoogleConversionLabel string
+	Clarityproject     string
+	GoogleTagManagerID string
 )
 
 // ClarityScript generates the Microsoft Clarity tracking script HTML.
@@ -115,27 +113,19 @@ func ClarityScript(ctx context.Context) template.HTML {
 	return template.HTML(script)
 }
 
-// GoogleTagScript generates the Google tag snippet HTML.
+// GoogleTagScript generates the Google Tag Manager snippet HTML.
 func GoogleTagScript() template.HTML {
-	if GoogleTagID == "" {
+	if GoogleTagManagerID == "" {
 		return ""
 	}
 
-	script := `<script async src="https://www.googletagmanager.com/gtag/js?id=` + GoogleTagID + `"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', '` + GoogleTagID + `');
+	script := `<script>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','` + template.JSEscapeString(GoogleTagManagerID) + `');
 </script>`
 
 	return template.HTML(script)
-}
-
-func GoogleConversionTag() string {
-	if GoogleTagID == "" || GoogleConversionLabel == "" {
-		return ""
-	}
-	return GoogleTagID + "/" + GoogleConversionLabel
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -434,16 +434,14 @@ func TestAuthEstablishTemplateChecksUserExistenceBeforeRedirect(t *testing.T) {
 	})
 
 	data := struct {
-		PublishableKey      string
-		GoogleTagScript     template.HTML
-		GoogleConversionTag string
-		UserExistsURL       string
-		ReturnTo            string
+		PublishableKey  string
+		GoogleTagScript template.HTML
+		UserExistsURL   string
+		ReturnTo        string
 	}{
-		PublishableKey:      "pk_test_123",
-		GoogleConversionTag: "AW-123/abc",
-		UserExistsURL:       "/auth/user-exists",
-		ReturnTo:            "/recipe/hash",
+		PublishableKey: "pk_test_123",
+		UserExistsURL:  "/auth/user-exists",
+		ReturnTo:       "/recipe/hash",
 	}
 
 	var buf bytes.Buffer
@@ -467,11 +465,11 @@ func TestAuthEstablishTemplateChecksUserExistenceBeforeRedirect(t *testing.T) {
 	if !strings.Contains(rendered, `if (!payload.exists &&`) {
 		t.Fatalf("auth establish page should gate conversion on missing user, body: %s", rendered)
 	}
-	if !strings.Contains(rendered, `send_to: "AW-123\/abc"`) {
-		t.Fatalf("auth establish page should emit configured conversion tag, body: %s", rendered)
+	if !strings.Contains(rendered, `event: "signup_completed"`) {
+		t.Fatalf("auth establish page should push signup event to dataLayer, body: %s", rendered)
 	}
-	if !strings.Contains(rendered, `event_callback: finishRedirect`) {
-		t.Fatalf("auth establish page should redirect after gtag callback, body: %s", rendered)
+	if !strings.Contains(rendered, `eventCallback: finishRedirect`) {
+		t.Fatalf("auth establish page should redirect after GTM event callback, body: %s", rendered)
 	}
 	if !strings.Contains(rendered, "console.warn(`auth user exists failed: ${response.status}`)") {
 		t.Fatalf("auth establish page should log when user exists endpoint returns a failure, body: %s", rendered)

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -44,6 +44,22 @@ func TestClarityScriptOmitsIdentifyWhenSessionIDEmpty(t *testing.T) {
 	}
 }
 
+func TestGoogleTagNoScriptIncludesContainerID(t *testing.T) {
+	prev := GoogleTagManagerID
+	t.Cleanup(func() {
+		GoogleTagManagerID = prev
+	})
+	GoogleTagManagerID = "GTM-KP55TPW6"
+
+	script := string(GoogleTagNoScript())
+	if !strings.Contains(script, `www.googletagmanager.com/ns.html?id=GTM-KP55TPW6`) {
+		t.Fatalf("expected GTM noscript iframe URL, got %q", script)
+	}
+	if !strings.Contains(script, `<!-- Google Tag Manager (noscript) -->`) {
+		t.Fatalf("expected GTM noscript comments, got %q", script)
+	}
+}
+
 func TestFullPageTemplatesIncludeSeasonalBackground(t *testing.T) {
 	for _, name := range []string{
 		"about.html",

--- a/internal/templates/user.html
+++ b/internal/templates/user.html
@@ -11,6 +11,7 @@
   {{.GoogleTagScript}}
 </head>
 <body class="min-h-screen bg-gradient-to-b from-brand-50 to-white antialiased">
+  {{GoogleTagNoScript}}
   {{template "seasonal_background" .}}
   <main class="relative px-4 py-10">
     <section class="mx-auto w-full max-w-4xl">


### PR DESCRIPTION
### Motivation
- Stop sending Google Ads conversions directly from the app and instead use GTM to keep application JavaScript minimal and centralize ad/pixel management. 
- Emit neutral `dataLayer` events for signup conversions so GTM can fan out events to ad platforms and third-party pixels. 
- Rename configuration to explicitly reflect GTM usage with `GOOGLE_TAG_MANAGER_ID` and remove the separate conversion label config. 

### Description
- Replaced `GoogleTagID`/`GoogleConversionLabel` with `GoogleTagManagerID` in `internal/templates/templates.go` and updated `GoogleTagScript` to emit a GTM loader snippet instead of the `gtag` snippet. 
- Updated `internal/templates/auth_establish.html` to push a `signup_completed` event to `window.dataLayer` (with `eventCallback`/`eventTimeout`) instead of calling `gtag('event', 'conversion', ...)`. 
- Adjusted code and templates that passed Google conversion data (`internal/auth/clerk.go`, template data structs) to remove conversion-specific fields and use the GTM script helper. 
- Added `docs/gtm-ads.md`, updated `README.md` and `AGENTS.md` to document `GOOGLE_TAG_MANAGER_ID`, and changed the `deploy.yaml` environment variables to set `GOOGLE_TAG_MANAGER_ID` instead of the previous Google tag/conversion vars. 
- Updated unit tests in `internal/templates` and `internal/recipes` to expect GTM script and `dataLayer` event behavior. 

### Testing
- Ran `go test ./...` and all tests completed successfully, including updated template tests in `internal/templates` and shopping-list/recipe HTML tests in `internal/recipes`. 
- Verified `AuthEstablish` template rendering assertions for the `signup_completed` `dataLayer` push and GTM script presence via the updated unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b91fce2c083298dbe65fc2794a39c)