### PR TITLE
Preserve add recipe action through sign-in

### DIFF
--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -545,7 +545,7 @@ func (s *server) handleSaveRecipe(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "recipe list hash not found", http.StatusBadRequest)
 		return
 	}
-	result, err := s.saveRecipeForUser(ctx, currentUser, shoppingListHash, recipeHash)
+	recipe, err := s.saveRecipeForUser(ctx, currentUser, shoppingListHash, recipeHash)
 	if err != nil {
 		if errors.Is(err, cache.ErrNotFound) {
 			http.Error(w, "recipe not found", http.StatusNotFound)
@@ -555,7 +555,6 @@ func (s *server) handleSaveRecipe(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to save recipe", http.StatusInternalServerError)
 		return
 	}
-	recipe := result.recipe
 
 	saved := true
 	var response bytes.Buffer
@@ -588,11 +587,7 @@ func (s *server) handleSaveRecipe(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type saveRecipeResult struct {
-	recipe *ai.Recipe
-}
-
-func (s *server) saveRecipeForUser(ctx context.Context, currentUser *utypes.User, shoppingListHash, recipeHash string) (*saveRecipeResult, error) {
+func (s *server) saveRecipeForUser(ctx context.Context, currentUser *utypes.User, shoppingListHash, recipeHash string) (*ai.Recipe, error) {
 	selection, err := s.loadRecipeSelection(ctx, currentUser.ID, shoppingListHash)
 	if err != nil {
 		return nil, fmt.Errorf("load recipe selection: %w", err)
@@ -616,7 +611,7 @@ func (s *server) saveRecipeForUser(ctx context.Context, currentUser *utypes.User
 	}
 	s.startSavedRecipeBackgroundGeneration(ctx, recipeHash, *recipe, params.Location.ID, params.Date)
 
-	return &saveRecipeResult{recipe: recipe}, nil
+	return recipe, nil
 }
 
 func (s *server) handleDismissRecipe(w http.ResponseWriter, r *http.Request) {

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -545,36 +545,17 @@ func (s *server) handleSaveRecipe(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "recipe list hash not found", http.StatusBadRequest)
 		return
 	}
-	selection, err := s.loadRecipeSelection(ctx, currentUser.ID, shoppingListHash)
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to load recipe selection for save", "shoppingListHash", shoppingListHash, "error", err)
-		http.Error(w, "failed to save recipe", http.StatusInternalServerError)
-		return
-	}
-	selection.markSaved(recipeHash)
-	if err := s.saveRecipeSelection(ctx, currentUser.ID, shoppingListHash, selection); err != nil {
-		slog.ErrorContext(ctx, "failed to save recipe selection", "shoppingListHash", shoppingListHash, "error", err)
-		http.Error(w, "failed to save recipe", http.StatusInternalServerError)
-		return
-	}
-
-	// could pass this in with htmx instead of loading title
-	recipe, err := s.SingleFromCache(ctx, recipeHash)
+	result, err := s.saveRecipeForUser(ctx, currentUser, shoppingListHash, recipeHash)
 	if err != nil {
 		if errors.Is(err, cache.ErrNotFound) {
 			http.Error(w, "recipe not found", http.StatusNotFound)
 			return
 		}
-		slog.ErrorContext(ctx, "failed to load recipe for profile save", "hash", recipeHash, "error", err)
-		http.Error(w, "failed to load recipe", http.StatusInternalServerError)
-		return
-	}
-
-	if err := s.saveRecipesToUserProfile(ctx, currentUser, *recipe); err != nil {
-		slog.ErrorContext(ctx, "failed to save recipe to user profile", "hash", recipeHash, "error", err)
+		slog.ErrorContext(ctx, "failed to save recipe", "shoppingListHash", shoppingListHash, "recipe_hash", recipeHash, "error", err)
 		http.Error(w, "failed to save recipe", http.StatusInternalServerError)
 		return
 	}
+	recipe := result.recipe
 
 	saved := true
 	var response bytes.Buffer
@@ -599,22 +580,43 @@ func (s *server) handleSaveRecipe(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// move into startSavedRecipeBackgroundGeneration
-	p, err := s.ParamsFromCache(ctx, shoppingListHash)
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to load params for save response", "shoppingListHash", shoppingListHash, "error", err)
-		http.Error(w, "failed to save recipe", http.StatusInternalServerError)
-		return
-	}
-
-	s.startSavedRecipeBackgroundGeneration(ctx, recipeHash, *recipe, p.Location.ID, p.Date)
-
 	setTextContent(w)
 	_, err = w.Write(response.Bytes())
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to write save response", "hash", recipeHash, "error", err)
 		http.Error(w, "failed to write response", http.StatusInternalServerError)
 	}
+}
+
+type saveRecipeResult struct {
+	recipe *ai.Recipe
+}
+
+func (s *server) saveRecipeForUser(ctx context.Context, currentUser *utypes.User, shoppingListHash, recipeHash string) (*saveRecipeResult, error) {
+	selection, err := s.loadRecipeSelection(ctx, currentUser.ID, shoppingListHash)
+	if err != nil {
+		return nil, fmt.Errorf("load recipe selection: %w", err)
+	}
+	selection.markSaved(recipeHash)
+	if err := s.saveRecipeSelection(ctx, currentUser.ID, shoppingListHash, selection); err != nil {
+		return nil, fmt.Errorf("save recipe selection: %w", err)
+	}
+
+	recipe, err := s.SingleFromCache(ctx, recipeHash)
+	if err != nil {
+		return nil, fmt.Errorf("load recipe: %w", err)
+	}
+	if err := s.saveRecipesToUserProfile(ctx, currentUser, *recipe); err != nil {
+		return nil, fmt.Errorf("save recipe to user profile: %w", err)
+	}
+
+	params, err := s.ParamsFromCache(ctx, shoppingListHash)
+	if err != nil {
+		return nil, fmt.Errorf("load recipe params: %w", err)
+	}
+	s.startSavedRecipeBackgroundGeneration(ctx, recipeHash, *recipe, params.Location.ID, params.Date)
+
+	return &saveRecipeResult{recipe: recipe}, nil
 }
 
 func (s *server) handleDismissRecipe(w http.ResponseWriter, r *http.Request) {
@@ -1079,23 +1081,19 @@ func (s *server) handleRecipes(w http.ResponseWriter, r *http.Request) {
 			selection = selection.override(userSelection)
 
 			if pendingSave := strings.TrimSpace(r.URL.Query().Get(queryArgPendingSave)); pendingSave != "" {
-				recipe, err := s.recipeFromShoppingList(*slist, pendingSave)
-				if err != nil {
+				if _, err := s.recipeFromShoppingList(*slist, pendingSave); err != nil {
 					http.Error(w, "recipe not found", http.StatusNotFound)
 					return
 				}
-				selection.markSaved(pendingSave)
-				if err := s.saveRecipeSelection(ctx, currentUser.ID, hashParam, selection); err != nil {
-					slog.ErrorContext(ctx, "failed to save pending recipe selection", "hash", hashParam, "recipe_hash", pendingSave, "error", err)
+				if _, err := s.saveRecipeForUser(ctx, currentUser, hashParam, pendingSave); err != nil {
+					if errors.Is(err, cache.ErrNotFound) {
+						http.Error(w, "recipe not found", http.StatusNotFound)
+						return
+					}
+					slog.ErrorContext(ctx, "failed to save pending recipe", "hash", hashParam, "recipe_hash", pendingSave, "error", err)
 					http.Error(w, "failed to save recipe", http.StatusInternalServerError)
 					return
 				}
-				if err := s.saveRecipesToUserProfile(ctx, currentUser, *recipe); err != nil {
-					slog.ErrorContext(ctx, "failed to save pending recipe to user profile", "hash", pendingSave, "error", err)
-					http.Error(w, "failed to save recipe", http.StatusInternalServerError)
-					return
-				}
-				s.startSavedRecipeBackgroundGeneration(ctx, pendingSave, *recipe, p.Location.ID, p.Date)
 				redirectToHash(w, r, hashParam, false /*useStart*/)
 				return
 			}

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -71,6 +71,19 @@ func redirectToSignIn(w http.ResponseWriter, r *http.Request, status int) {
 	http.Error(w, "must be logged in", status)
 }
 
+func redirectToSignInForSave(w http.ResponseWriter, r *http.Request, shoppingListHash, recipeHash string, status int) {
+	returnTo := requestURIOrPath(r)
+	if shoppingListHash != "" && recipeHash != "" {
+		values := url.Values{queryArgHash: []string{shoppingListHash}, queryArgPendingSave: []string{recipeHash}}
+		returnTo = "/recipes?" + values.Encode()
+	}
+	target := signInPath(returnTo)
+	if isHTMXRequest(r) {
+		w.Header().Set("HX-Redirect", target)
+	}
+	http.Error(w, "must be logged in", status)
+}
+
 const (
 	guestShoppingListCookieName = "careme_guest_shopping_lists"
 	guestShoppingListLimit      = 2
@@ -512,22 +525,22 @@ func (s *server) handleSaveRecipe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	currentUser, err := s.storage.FromRequest(ctx, r, s.clerk)
-	if err != nil {
-		if errors.Is(err, auth.ErrNoSession) {
-			redirectToSignIn(w, r, http.StatusUnauthorized)
-			return
-		}
-		slog.ErrorContext(ctx, "failed to load user for recipe save", "error", err)
-		http.Error(w, "unable to load account", http.StatusInternalServerError)
-		return
-	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "invalid form", http.StatusBadRequest)
 		return
 	}
 
 	shoppingListHash := strings.TrimSpace(r.FormValue(queryArgHash))
+	currentUser, err := s.storage.FromRequest(ctx, r, s.clerk)
+	if err != nil {
+		if errors.Is(err, auth.ErrNoSession) {
+			redirectToSignInForSave(w, r, shoppingListHash, recipeHash, http.StatusUnauthorized)
+			return
+		}
+		slog.ErrorContext(ctx, "failed to load user for recipe save", "error", err)
+		http.Error(w, "unable to load account", http.StatusInternalServerError)
+		return
+	}
 	if shoppingListHash == "" {
 		http.Error(w, "recipe list hash not found", http.StatusBadRequest)
 		return
@@ -941,9 +954,19 @@ func paramsForAction(ctx context.Context, hash, userID, instructions string, io 
 }
 
 const (
-	queryArgHash  = "h"
-	queryArgStart = "start"
+	queryArgHash        = "h"
+	queryArgStart       = "start"
+	queryArgPendingSave = "save"
 )
+
+func (s *server) recipeFromShoppingList(list ai.ShoppingList, recipeHash string) (*ai.Recipe, error) {
+	for i := range list.Recipes {
+		if list.Recipes[i].ComputeHash() == recipeHash {
+			return &list.Recipes[i], nil
+		}
+	}
+	return nil, cache.ErrNotFound
+}
 
 func (s *server) notFound(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	startArg := r.URL.Query().Get(queryArgStart)
@@ -1054,6 +1077,28 @@ func (s *server) handleRecipes(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			selection = selection.override(userSelection)
+
+			if pendingSave := strings.TrimSpace(r.URL.Query().Get(queryArgPendingSave)); pendingSave != "" {
+				recipe, err := s.recipeFromShoppingList(*slist, pendingSave)
+				if err != nil {
+					http.Error(w, "recipe not found", http.StatusNotFound)
+					return
+				}
+				selection.markSaved(pendingSave)
+				if err := s.saveRecipeSelection(ctx, currentUser.ID, hashParam, selection); err != nil {
+					slog.ErrorContext(ctx, "failed to save pending recipe selection", "hash", hashParam, "recipe_hash", pendingSave, "error", err)
+					http.Error(w, "failed to save recipe", http.StatusInternalServerError)
+					return
+				}
+				if err := s.saveRecipesToUserProfile(ctx, currentUser, *recipe); err != nil {
+					slog.ErrorContext(ctx, "failed to save pending recipe to user profile", "hash", pendingSave, "error", err)
+					http.Error(w, "failed to save recipe", http.StatusInternalServerError)
+					return
+				}
+				s.startSavedRecipeBackgroundGeneration(ctx, pendingSave, *recipe, p.Location.ID, p.Date)
+				redirectToHash(w, r, hashParam, false /*useStart*/)
+				return
+			}
 		}
 		if r.URL.Query().Get("mail") == "true" {
 			tf := users.NewUnsubscribeTokenFactory(*s.cfg)

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -1247,6 +1247,23 @@ func TestHandleSaveRecipe_NoSessionHTMXSetsRedirectHeaderToShoppingListPendingSa
 	}
 }
 
+func TestHandleSaveRecipe_NoSessionFromRecipePageRedirectsToShoppingListPendingSave(t *testing.T) {
+	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
+	s := newTestServer(t, withTestCache(cacheStore), withTestClerk(noSessionAuth{}))
+
+	form := url.Values{"h": {"origin-hash"}, "source": {"recipe"}}
+	req := httptest.NewRequest(http.MethodPost, "/recipe/recipe-hash/save", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.SetPathValue("hash", "recipe-hash")
+	rr := httptest.NewRecorder()
+
+	s.handleSaveRecipe(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.Equal(t, signInPath("/recipes?h=origin-hash&save=recipe-hash"), rr.Header().Get("HX-Redirect"))
+}
+
 func TestHandleRecipes_PendingSaveAfterSignInAddsRecipeAndRedirects(t *testing.T) {
 	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
 	storage := users.NewStorage(cacheStore)

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -1226,11 +1226,13 @@ func TestHandleSaveRecipe_SavesRecipeToUserProfile(t *testing.T) {
 	}
 }
 
-func TestHandleSaveRecipe_NoSessionHTMXSetsRedirectHeader(t *testing.T) {
+func TestHandleSaveRecipe_NoSessionHTMXSetsRedirectHeaderToShoppingListPendingSave(t *testing.T) {
 	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
 	s := newTestServer(t, withTestCache(cacheStore), withTestClerk(noSessionAuth{}))
 
-	req := httptest.NewRequest(http.MethodPost, "/recipe/hash/save", nil)
+	form := url.Values{"h": {"shopping-hash"}}
+	req := httptest.NewRequest(http.MethodPost, "/recipe/hash/save", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("HX-Request", "true")
 	req.SetPathValue("hash", "hash")
 	rr := httptest.NewRecorder()
@@ -1240,9 +1242,46 @@ func TestHandleSaveRecipe_NoSessionHTMXSetsRedirectHeader(t *testing.T) {
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
 	}
-	if got, want := rr.Header().Get("HX-Redirect"), signInPath("/recipe/hash/save"); got != want {
+	if got, want := rr.Header().Get("HX-Redirect"), signInPath("/recipes?h=shopping-hash&save=hash"); got != want {
 		t.Fatalf("expected HX-Redirect %q, got %q", want, got)
 	}
+}
+
+func TestHandleRecipes_PendingSaveAfterSignInAddsRecipeAndRedirects(t *testing.T) {
+	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
+	storage := users.NewStorage(cacheStore)
+	s := newTestServer(t,
+		withTestCache(cacheStore),
+		withTestStorage(storage),
+	)
+
+	recipe := ai.Recipe{
+		Title:       "Save After Login",
+		Description: "Recipe to save after login",
+		ResponseID:  "resp-pending-save",
+	}
+	params := DefaultParams(&locations.Location{ID: "70004001", Name: "Store"}, time.Now())
+	hash := params.Hash()
+	recipeHash := recipe.ComputeHash()
+	require.NoError(t, s.SaveParams(t.Context(), params))
+	saveRecipesForOrigin(t, s, hash, recipe)
+	require.NoError(t, s.SaveShoppingList(t.Context(), &ai.ShoppingList{Recipes: []ai.Recipe{recipe}}, hash))
+
+	req := httptest.NewRequest(http.MethodGet, "/recipes?h="+hash+"&save="+recipeHash, nil)
+	rr := httptest.NewRecorder()
+
+	s.handleRecipes(rr, req)
+	s.Wait()
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Equal(t, "/recipes?h="+hash, rr.Header().Get("Location"))
+	selection, err := s.loadRecipeSelection(t.Context(), "mock-clerk-user-id", hash)
+	require.NoError(t, err)
+	require.Equal(t, []string{recipeHash}, selection.SavedHashes)
+	user, err := storage.GetByID("mock-clerk-user-id")
+	require.NoError(t, err)
+	require.Len(t, user.LastRecipes, 1)
+	require.Equal(t, recipeHash, user.LastRecipes[0].Hash)
 }
 
 func TestHandleSaveRecipe_UsesRequestHashForSelectionKey(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Fix the flow where clicking Add while signed out redirected back to the POST-only `/recipe/{hash}/save` endpoint and produced a method-not-supported error after sign-in.
- Ensure the user's intent to add a recipe is preserved across the sign-in redirect and applied after authentication.

### Description
- Introduced `redirectToSignInForSave` to redirect signed-out HTMX `save` attempts to `/sign-in` with a return-to of `/recipes?h=<hash>&save=<recipe>` instead of the POST-only save endpoint, and added `queryArgPendingSave = "save"` to the query constants.
- Updated `handleSaveRecipe` to include the shopping-list hash from the form and to call `redirectToSignInForSave` when there is no session.
- Added `recipeFromShoppingList` helper and implemented pending-save handling in `handleRecipes` that, after sign-in, locates the pending recipe in the shopping list, marks it saved, persists the selection, saves the recipe to the user profile, starts background work, and redirects back to the clean shopping list URL.
- Added/updated tests in `internal/recipes/server_test.go` to assert the new HX-Redirect target for signed-out saves and to cover the end-to-end pending-save application after sign-in.

### Testing
- Ran the targeted tests: `go test ./internal/recipes -run 'TestHandleRecipes_PendingSaveAfterSignInAddsRecipeAndRedirects|TestHandleSaveRecipe_NoSession'` which passed.
- Ran the full test suite with `go test ./...` which completed successfully for all packages.
- Attempted `golangci-lint run ./...` but it failed in this environment because the installed `golangci-lint` was built with Go 1.24 while the repository targets Go 1.26, so linting was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d9b53c04832991071422955d4741)