### PR TITLE
Allow regenerating recipe follow-ups

### DIFF
--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -245,6 +245,10 @@ func (g *generatorService) replacementMenuPlan(ctx context.Context, p *generator
 	return plan, nil
 }
 
+func (g *generatorService) RegenerateRecipe(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	return g.aiClient.Regenerate(ctx, instructions, previousResponseID)
+}
+
 // generator not prociding a lot of value here. Should sever just hold an ai client?
 func (g *generatorService) AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error) {
 	return g.aiClient.AskQuestion(ctx, question, previousResponseID)

--- a/internal/recipes/html.go
+++ b/internal/recipes/html.go
@@ -215,17 +215,19 @@ func recipeImageData(recipeHash string, hasImage bool, outOfBand bool) recipeIma
 }
 
 // FormatRecipeThreadHTML renders the question thread fragment for HTMX swaps.
-func FormatRecipeThreadHTML(thread []RecipeThreadEntry, signedIn bool, responseID string, writer http.ResponseWriter) {
+func FormatRecipeThreadHTML(thread []RecipeThreadEntry, signedIn bool, responseID, recipeHash string, writer http.ResponseWriter) {
 	// memory waste because we alwways resort?
 	slices.SortFunc(thread, func(i, j RecipeThreadEntry) int {
 		return j.CreatedAt.Compare(i.CreatedAt)
 	})
 	data := struct {
 		ResponseID     string
+		RecipeHash     string
 		Thread         []RecipeThreadEntry
 		ServerSignedIn bool
 	}{
 		ResponseID:     responseID,
+		RecipeHash:     recipeHash,
 		Thread:         thread,
 		ServerSignedIn: signedIn,
 	}

--- a/internal/recipes/html_test.go
+++ b/internal/recipes/html_test.go
@@ -752,7 +752,7 @@ func TestFormatRecipeThreadHTML_SortsNewestFirst(t *testing.T) {
 		},
 	}
 
-	FormatRecipeThreadHTML(thread, true, "conv123", w)
+	FormatRecipeThreadHTML(thread, true, "conv123", "recipe123", w)
 	body := assertHTTPSuccess(t, w)
 
 	newerIndex := strings.Index(body, "newer question")

--- a/internal/recipes/mock.go
+++ b/internal/recipes/mock.go
@@ -417,6 +417,16 @@ func (m mock) GenerateRecipes(ctx context.Context, p *generatorParams) (*ai.Shop
 	}, nil
 }
 
+func (m mock) RegenerateRecipe(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	_ = ctx
+	_ = instructions
+	_ = previousResponseID
+	recipe := mockRecipes[0]
+	recipe.Title = "Fresh " + recipe.Title
+	recipe.ResponseID = uuid.NewString()
+	return &recipe, nil
+}
+
 func (m mock) AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error) {
 	_ = previousResponseID
 	return &ai.QuestionResponse{

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -433,7 +433,7 @@ func (s *server) handleQuestion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	FormatRecipeThreadHTML(thread, true, answer.ResponseID, w)
+	FormatRecipeThreadHTML(thread, true, answer.ResponseID, hash, w)
 }
 
 func (s *server) handleRegenerateSingleRecipe(w http.ResponseWriter, r *http.Request) {
@@ -495,7 +495,7 @@ func (s *server) handleRegenerateSingleRecipe(w http.ResponseWriter, r *http.Req
 		http.Error(w, "failed to save refreshed recipe", http.StatusInternalServerError)
 		return
 	}
-	replaced, err := s.storage.ReplaceRecipe(currentUser, hash, utypes.Recipe{
+	err := s.storage.ReplaceRecipe(currentUser, hash, utypes.Recipe{
 		Title:     replacement.Title,
 		Hash:      newHash,
 		CreatedAt: time.Now(),
@@ -505,11 +505,6 @@ func (s *server) handleRegenerateSingleRecipe(w http.ResponseWriter, r *http.Req
 		http.Error(w, "failed to save refreshed recipe", http.StatusInternalServerError)
 		return
 	}
-	if !replaced {
-		http.Error(w, "save the recipe before refreshing it", http.StatusBadRequest)
-		return
-	}
-
 	http.Redirect(w, r, "/recipe/"+url.PathEscape(newHash), http.StatusSeeOther)
 }
 

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -495,7 +495,7 @@ func (s *server) handleRegenerateSingleRecipe(w http.ResponseWriter, r *http.Req
 		http.Error(w, "failed to save refreshed recipe", http.StatusInternalServerError)
 		return
 	}
-	err := s.storage.ReplaceRecipe(currentUser, hash, utypes.Recipe{
+	replaced, err := s.storage.ReplaceRecipe(currentUser, hash, utypes.Recipe{
 		Title:     replacement.Title,
 		Hash:      newHash,
 		CreatedAt: time.Now(),
@@ -505,6 +505,14 @@ func (s *server) handleRegenerateSingleRecipe(w http.ResponseWriter, r *http.Req
 		http.Error(w, "failed to save refreshed recipe", http.StatusInternalServerError)
 		return
 	}
+	if replaced {
+		if params, err := s.ParamsFromCache(ctx, recipe.OriginHash); err != nil {
+			slog.ErrorContext(ctx, "couldn't look up params", "hash", newHash, "origin", recipe.OriginHash)
+		} else {
+			s.startSavedRecipeBackgroundGeneration(ctx, newHash, *replacement, params.Location.ID, params.Date)
+		}
+	}
+
 	http.Redirect(w, r, "/recipe/"+url.PathEscape(newHash), http.StatusSeeOther)
 }
 

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -295,19 +296,16 @@ func (s *server) handleSingle(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "recipe's origin shpppinglist not found or expired", http.StatusInternalServerError)
 		return
 	}
-	selection := selectionFromSaved(p.Saved)
+	saved := false
 	if signedIn {
-		latestSel, selErr := s.loadRecipeSelection(ctx, currentUser.ID, recipe.OriginHash)
-		if selErr != nil {
-			slog.ErrorContext(ctx, "failed to load recipe selection for single recipe render", "hash", recipe.OriginHash, "error", selErr)
-			http.Error(w, "failed to load recipe selection", http.StatusInternalServerError)
-			return
-		}
-		selection = selection.override(latestSel)
+		// this is going to be slow once we paginate recipes...
+		saved = slices.ContainsFunc(currentUser.LastRecipes, func(r utypes.Recipe) bool {
+			return r.Hash == hash
+		})
 	}
 
 	slog.InfoContext(ctx, "serving recipe by hash", "hash", hash, "signedIn", signedIn)
-	FormatRecipeHTML(ctx, p, *recipe, selection.IsSaved(recipe.ComputeHash()), currentUser, critiqueScore, hasRecipeImage, thread, feedback, wineRecommendation, w)
+	FormatRecipeHTML(ctx, p, *recipe, saved, currentUser, critiqueScore, hasRecipeImage, thread, feedback, wineRecommendation, w)
 }
 
 func (s *server) handleRecipeImage(w http.ResponseWriter, r *http.Request) {

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -441,42 +441,62 @@ func (s *server) handleRegenerateSingleRecipe(w http.ResponseWriter, r *http.Req
 		http.Error(w, "missing recipe hash", http.StatusBadRequest)
 		return
 	}
-	currentUser, err := s.storage.FromRequest(ctx, r, s.clerk)
-	if err != nil {
-		if errors.Is(err, auth.ErrNoSession) {
+
+	var (
+		currentUser *utypes.User
+		recipe      *ai.Recipe
+		thread      []RecipeThreadEntry
+		userErr     error
+		recipeErr   error
+		threadErr   error
+		loadWG      sync.WaitGroup
+	)
+	loadWG.Go(func() {
+		currentUser, userErr = s.storage.FromRequest(ctx, r, s.clerk)
+	})
+	loadWG.Go(func() {
+		recipe, recipeErr = s.SingleFromCache(ctx, hash)
+	})
+	loadWG.Go(func() {
+		thread, threadErr = s.ThreadFromCache(ctx, hash)
+	})
+	loadWG.Wait()
+
+	if userErr != nil {
+		if errors.Is(userErr, auth.ErrNoSession) {
 			redirectToSignIn(w, r, http.StatusUnauthorized)
 			return
 		}
-		slog.ErrorContext(ctx, "failed to load user for recipe regeneration", "hash", hash, "error", err)
+		slog.ErrorContext(ctx, "failed to load user for recipe regeneration", "hash", hash, "error", userErr)
 		http.Error(w, "unable to load account", http.StatusInternalServerError)
 		return
 	}
-	recipe, err := s.SingleFromCache(ctx, hash)
-	if err != nil {
-		if errors.Is(err, cache.ErrNotFound) {
+	if recipeErr != nil {
+		if errors.Is(recipeErr, cache.ErrNotFound) {
 			http.Error(w, "recipe not found", http.StatusNotFound)
 			return
 		}
-		slog.ErrorContext(ctx, "failed to load recipe for regeneration", "hash", hash, "error", err)
+		slog.ErrorContext(ctx, "failed to load recipe for regeneration", "hash", hash, "error", recipeErr)
 		http.Error(w, "failed to load recipe", http.StatusInternalServerError)
 		return
 	}
-	thread, err := s.ThreadFromCache(ctx, hash)
-	if err != nil {
-		if errors.Is(err, cache.ErrNotFound) {
+	if threadErr != nil {
+		if errors.Is(threadErr, cache.ErrNotFound) {
 			http.Error(w, "ask a question before refreshing this recipe", http.StatusBadRequest)
 			return
 		}
-		slog.ErrorContext(ctx, "failed to load recipe thread for regeneration", "hash", hash, "error", err)
+		slog.ErrorContext(ctx, "failed to load recipe thread for regeneration", "hash", hash, "error", threadErr)
 		http.Error(w, "failed to load recipe questions", http.StatusInternalServerError)
 		return
 	}
 	responseID := latestThreadResponseID(thread)
 	if responseID == "" {
+		// should never get here
 		http.Error(w, "ask a question before refreshing this recipe", http.StatusBadRequest)
 		return
 	}
 
+	// spin page?
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 90*time.Second)
 	defer cancel()
 	replacement, err := s.generator.RegenerateRecipe(ctx, []string{"Rewrite the recipe to incorporate the user's question thread and your answers. Return a complete updated recipe."}, responseID)
@@ -485,6 +505,7 @@ func (s *server) handleRegenerateSingleRecipe(w http.ResponseWriter, r *http.Req
 		http.Error(w, "failed to refresh recipe", http.StatusInternalServerError)
 		return
 	}
+	// TODO generate a new shoppinglist? only if ingredients changed or user asked?
 	replacement.OriginHash = recipe.OriginHash
 	replacement.ParentHash = hash
 	newHash := replacement.ComputeHash()

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -120,6 +120,7 @@ type locServer interface {
 
 type generator interface {
 	GenerateRecipes(ctx context.Context, p *generatorParams) (*ai.ShoppingList, error)
+	RegenerateRecipe(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error)
 	AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error)
 	PickAWine(ctx context.Context, location string, recipe ai.Recipe, date time.Time) (*ai.WineSelection, error)
 }
@@ -176,6 +177,7 @@ func (s *server) Register(mux routing.Registrar) {
 	mux.HandleFunc("GET /recipe/{hash}", s.handleSingle)
 	mux.HandleFunc("GET /recipe/{hash}/image", s.handleRecipeImage)
 	mux.HandleFunc("POST /recipe/{hash}/question", s.handleQuestion)
+	mux.HandleFunc("POST /recipe/{hash}/regenerate", s.handleRegenerateSingleRecipe)
 	mux.HandleFunc("POST /recipe/{hash}/feedback", s.handleFeedback)
 	mux.HandleFunc("POST /recipe/{hash}/save", s.handleSaveRecipe)
 	mux.HandleFunc("POST /recipe/{hash}/dismiss", s.handleDismissRecipe)
@@ -432,6 +434,83 @@ func (s *server) handleQuestion(w http.ResponseWriter, r *http.Request) {
 	}
 
 	FormatRecipeThreadHTML(thread, true, answer.ResponseID, w)
+}
+
+func (s *server) handleRegenerateSingleRecipe(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	hash := strings.TrimSpace(r.PathValue("hash"))
+	if hash == "" {
+		http.Error(w, "missing recipe hash", http.StatusBadRequest)
+		return
+	}
+	currentUser, err := s.storage.FromRequest(ctx, r, s.clerk)
+	if err != nil {
+		if errors.Is(err, auth.ErrNoSession) {
+			redirectToSignIn(w, r, http.StatusUnauthorized)
+			return
+		}
+		slog.ErrorContext(ctx, "failed to load user for recipe regeneration", "hash", hash, "error", err)
+		http.Error(w, "unable to load account", http.StatusInternalServerError)
+		return
+	}
+	recipe, err := s.SingleFromCache(ctx, hash)
+	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			http.Error(w, "recipe not found", http.StatusNotFound)
+			return
+		}
+		slog.ErrorContext(ctx, "failed to load recipe for regeneration", "hash", hash, "error", err)
+		http.Error(w, "failed to load recipe", http.StatusInternalServerError)
+		return
+	}
+	thread, err := s.ThreadFromCache(ctx, hash)
+	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			http.Error(w, "ask a question before refreshing this recipe", http.StatusBadRequest)
+			return
+		}
+		slog.ErrorContext(ctx, "failed to load recipe thread for regeneration", "hash", hash, "error", err)
+		http.Error(w, "failed to load recipe questions", http.StatusInternalServerError)
+		return
+	}
+	responseID := latestThreadResponseID(thread)
+	if responseID == "" {
+		http.Error(w, "ask a question before refreshing this recipe", http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 90*time.Second)
+	defer cancel()
+	replacement, err := s.generator.RegenerateRecipe(ctx, []string{"Rewrite the recipe to incorporate the user's question thread and your answers. Return a complete updated recipe."}, responseID)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to regenerate single recipe", "hash", hash, "error", err)
+		http.Error(w, "failed to refresh recipe", http.StatusInternalServerError)
+		return
+	}
+	replacement.OriginHash = recipe.OriginHash
+	replacement.ParentHash = hash
+	newHash := replacement.ComputeHash()
+	if err := s.SaveRecipe(ctx, *replacement); err != nil {
+		slog.ErrorContext(ctx, "failed to save regenerated single recipe", "hash", hash, "new_hash", newHash, "error", err)
+		http.Error(w, "failed to save refreshed recipe", http.StatusInternalServerError)
+		return
+	}
+	replaced, err := s.storage.ReplaceRecipe(currentUser, hash, utypes.Recipe{
+		Title:     replacement.Title,
+		Hash:      newHash,
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to replace user saved recipe", "hash", hash, "new_hash", newHash, "error", err)
+		http.Error(w, "failed to save refreshed recipe", http.StatusInternalServerError)
+		return
+	}
+	if !replaced {
+		http.Error(w, "save the recipe before refreshing it", http.StatusBadRequest)
+		return
+	}
+
+	http.Redirect(w, r, "/recipe/"+url.PathEscape(newHash), http.StatusSeeOther)
 }
 
 func (s *server) handleFeedback(w http.ResponseWriter, r *http.Request) {

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -1143,8 +1143,11 @@ func TestHandleQuestion_HTMXReturnsThreadFragment(t *testing.T) {
 	if !strings.Contains(body, `name="response_id" value="resp-next"`) {
 		t.Fatalf("expected updated response id in thread fragment, got body: %s", body)
 	}
-	if !strings.Contains(body, `action="/recipe/`+recipeHash+`/regenerate"`) || !strings.Contains(body, "Try again, chef") {
+	if !strings.Contains(body, `action="/recipe/`+recipeHash+`/regenerate"`) || !strings.Contains(body, "Tweak it, chef") {
 		t.Fatalf("expected regenerate action after first question, got body: %s", body)
+	}
+	if !strings.Contains(body, `button.textContent='Tweaking...'; button.disabled=true;`) {
+		t.Fatalf("expected regenerate action to show its pending state, got body: %s", body)
 	}
 }
 

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -656,7 +656,7 @@ func TestHandleSingle_IncludesCachedWineRecommendation(t *testing.T) {
 	}
 }
 
-func TestHandleSingle_UsesSelectionForSavedState(t *testing.T) {
+func TestHandleSingle_UsesUserProfileForSavedState(t *testing.T) {
 	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
 	s := newTestServer(t, withTestCache(cacheStore))
 
@@ -678,8 +678,16 @@ func TestHandleSingle_UsesSelectionForSavedState(t *testing.T) {
 	}
 	recipeHash := recipe.ComputeHash()
 	saveRecipesForOrigin(t, s, originHash, recipe)
-	require.NoError(t, s.saveRecipeSelection(t.Context(), "mock-clerk-user-id", originHash, recipeSelection{
-		SavedHashes: []string{recipeHash},
+	require.NoError(t, s.storage.Update(&utypes.User{
+		ID:          "mock-clerk-user-id",
+		Email:       []string{"you@careme.cooking"},
+		CreatedAt:   time.Now(),
+		ShoppingDay: time.Saturday.String(),
+		LastRecipes: []utypes.Recipe{{
+			Title:     recipe.Title,
+			Hash:      recipeHash,
+			CreatedAt: time.Now(),
+		}},
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/recipe/"+recipeHash, nil)

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -1143,6 +1143,9 @@ func TestHandleQuestion_HTMXReturnsThreadFragment(t *testing.T) {
 	if !strings.Contains(body, `name="response_id" value="resp-next"`) {
 		t.Fatalf("expected updated response id in thread fragment, got body: %s", body)
 	}
+	if !strings.Contains(body, `action="/recipe/`+recipeHash+`/regenerate"`) || !strings.Contains(body, "Try again, chef") {
+		t.Fatalf("expected regenerate action after first question, got body: %s", body)
+	}
 }
 
 func TestHandleQuestion_NoSessionHTMXSetsRedirectHeader(t *testing.T) {

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -787,6 +787,76 @@ func TestHandleQuestion_RejectsNonHTMXRequest(t *testing.T) {
 	}
 }
 
+func TestHandleRegenerateSingleRecipe_ReplacesSavedRecipeWithoutChangingShoppingList(t *testing.T) {
+	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
+	storage := users.NewStorage(cacheStore)
+	generator := &captureQuestionGenerator{}
+	s := newTestServer(t,
+		withTestCache(cacheStore),
+		withTestStorage(storage),
+		withTestGenerator(generator),
+	)
+
+	now := time.Now()
+	params := DefaultParams(&locations.Location{ID: "70001001", Name: "Store"}, now)
+	shoppingListHash := params.Hash()
+	original := ai.Recipe{
+		Title:        "Original Steak Dinner",
+		Description:  "Original.",
+		Ingredients:  []ai.Ingredient{{Name: "Steak", Quantity: "1 lb"}},
+		Instructions: []string{"Cook steak.", "Serve."},
+		OriginHash:   shoppingListHash,
+		ResponseID:   "resp-original",
+	}
+	originalHash := original.ComputeHash()
+	params.Saved = []ai.Recipe{original}
+	require.NoError(t, s.SaveParams(t.Context(), params))
+	require.NoError(t, s.SaveRecipe(t.Context(), original))
+	require.NoError(t, s.SaveShoppingList(t.Context(), &ai.ShoppingList{Recipes: []ai.Recipe{original}}, shoppingListHash))
+	require.NoError(t, s.SaveThread(t.Context(), originalHash, []RecipeThreadEntry{{
+		Question:   "Can I use skirt steak?",
+		Answer:     "Yes.",
+		ResponseID: "resp-question",
+		CreatedAt:  now,
+	}}))
+	user := &utypes.User{
+		ID:          "mock-clerk-user-id",
+		Email:       []string{"you@careme.cooking"},
+		CreatedAt:   now,
+		ShoppingDay: time.Saturday.String(),
+		LastRecipes: []utypes.Recipe{{Title: original.Title, Hash: originalHash, CreatedAt: now}},
+	}
+	require.NoError(t, storage.Update(user))
+
+	req := httptest.NewRequest(http.MethodPost, "/recipe/"+url.PathEscape(originalHash)+"/regenerate", nil)
+	req.SetPathValue("hash", originalHash)
+	rr := httptest.NewRecorder()
+
+	s.handleRegenerateSingleRecipe(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	newLocation := rr.Header().Get("Location")
+	require.Contains(t, newLocation, "/recipe/")
+	newHash := strings.TrimPrefix(newLocation, "/recipe/")
+	require.NotEqual(t, originalHash, newHash)
+
+	updatedUser, err := storage.GetByID("mock-clerk-user-id")
+	require.NoError(t, err)
+	require.Len(t, updatedUser.LastRecipes, 1)
+	assert.Equal(t, newHash, updatedUser.LastRecipes[0].Hash)
+	assert.Equal(t, "Updated Skirt Steak Dinner", updatedUser.LastRecipes[0].Title)
+
+	updatedRecipe, err := s.SingleFromCache(t.Context(), newHash)
+	require.NoError(t, err)
+	assert.Equal(t, originalHash, updatedRecipe.ParentHash)
+	assert.Equal(t, shoppingListHash, updatedRecipe.OriginHash)
+
+	shoppingList, err := s.FromCache(t.Context(), shoppingListHash)
+	require.NoError(t, err)
+	require.Len(t, shoppingList.Recipes, 1)
+	assert.Equal(t, originalHash, shoppingList.Recipes[0].ComputeHash())
+}
+
 type captureKickgenerationGenerator struct {
 	mu     sync.Mutex
 	last   *generatorParams
@@ -814,6 +884,10 @@ func (c *captureKickgenerationGenerator) GenerateRecipes(ctx context.Context, p 
 		return nil, c.err
 	}
 	return &ai.ShoppingList{}, nil
+}
+
+func (c *captureKickgenerationGenerator) RegenerateRecipe(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	panic("unexpected call to RegenerateRecipe")
 }
 
 func (c *captureKickgenerationGenerator) AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error) {
@@ -940,6 +1014,16 @@ type captureQuestionGenerator struct {
 
 func (c *captureQuestionGenerator) GenerateRecipes(ctx context.Context, p *generatorParams) (*ai.ShoppingList, error) {
 	return &ai.ShoppingList{}, nil
+}
+
+func (c *captureQuestionGenerator) RegenerateRecipe(ctx context.Context, instructions []string, previousResponseID string) (*ai.Recipe, error) {
+	return &ai.Recipe{
+		Title:        "Updated Skirt Steak Dinner",
+		Description:  "Updated after questions.",
+		Ingredients:  []ai.Ingredient{{Name: "Skirt steak", Quantity: "1 lb"}},
+		Instructions: []string{"Cook the steak.", "Serve."},
+		ResponseID:   "resp-regenerated",
+	}, nil
 }
 
 func (c *captureQuestionGenerator) AskQuestion(ctx context.Context, question string, previousResponseID string) (*ai.QuestionResponse, error) {

--- a/internal/templates/recipe.html
+++ b/internal/templates/recipe.html
@@ -312,10 +312,13 @@
   <p class="text-sm text-gray-500">No questions yet.</p>
   {{end}}
   {{if and .ServerSignedIn .Thread}}
-  <form method="POST" action="/recipe/{{.RecipeHash}}/regenerate" class="pt-2">
+  <form method="POST"
+        action="/recipe/{{.RecipeHash}}/regenerate"
+        onsubmit="const button=this.querySelector('button[type=submit]'); button.textContent='Tweaking...'; button.disabled=true;"
+        class="pt-2">
     <button type="submit"
-            class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
-      Try again, chef
+            class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-brand-400 disabled:text-white/90">
+      Tweak it, chef
     </button>
     <p class="mt-2 text-xs text-gray-500">Keeps this version linked, updates your saved recipe, and leaves the shopping list as-is.</p>
   </form>

--- a/internal/templates/recipe.html
+++ b/internal/templates/recipe.html
@@ -219,6 +219,15 @@
             {{end}}
 
             {{template "recipe_thread" .}}
+            {{if and .ServerSignedIn .Thread}}
+            <form method="POST" action="/recipe/{{.RecipeHash}}/regenerate" class="pt-2">
+              <button type="submit"
+                      class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
+                Try again, chef
+              </button>
+              <p class="mt-2 text-xs text-gray-500">Keeps this version linked, updates your saved recipe, and leaves the shopping list as-is.</p>
+            </form>
+            {{end}}
           </section>
 
         </div>

--- a/internal/templates/recipe.html
+++ b/internal/templates/recipe.html
@@ -219,15 +219,6 @@
             {{end}}
 
             {{template "recipe_thread" .}}
-            {{if and .ServerSignedIn .Thread}}
-            <form method="POST" action="/recipe/{{.RecipeHash}}/regenerate" class="pt-2">
-              <button type="submit"
-                      class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
-                Try again, chef
-              </button>
-              <p class="mt-2 text-xs text-gray-500">Keeps this version linked, updates your saved recipe, and leaves the shopping list as-is.</p>
-            </form>
-            {{end}}
           </section>
 
         </div>
@@ -319,6 +310,15 @@
   </div>
   {{else if and .ServerSignedIn .ResponseID}}
   <p class="text-sm text-gray-500">No questions yet.</p>
+  {{end}}
+  {{if and .ServerSignedIn .Thread}}
+  <form method="POST" action="/recipe/{{.RecipeHash}}/regenerate" class="pt-2">
+    <button type="submit"
+            class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
+      Try again, chef
+    </button>
+    <p class="mt-2 text-xs text-gray-500">Keeps this version linked, updates your saved recipe, and leaves the shopping list as-is.</p>
+  </form>
   {{end}}
 </div>
 {{end}}

--- a/internal/users/storage.go
+++ b/internal/users/storage.go
@@ -177,6 +177,33 @@ func (s *Storage) RemoveRecipe(user *utypes.User, recipeHash string) (bool, erro
 	return true, nil
 }
 
+func (s *Storage) ReplaceRecipe(user *utypes.User, oldHash string, replacement utypes.Recipe) (bool, error) {
+	oldHash = strings.TrimSpace(oldHash)
+	replacement.Hash = strings.TrimSpace(replacement.Hash)
+	if oldHash == "" || replacement.Hash == "" {
+		return false, fmt.Errorf("invalid recipe hash")
+	}
+	if user == nil {
+		return false, fmt.Errorf("user is required")
+	}
+
+	replaced := false
+	for i := range user.LastRecipes {
+		if user.LastRecipes[i].Hash == oldHash {
+			user.LastRecipes[i] = replacement
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		return false, nil
+	}
+	if err := s.Update(user); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func normalizeEmail(email string) string {
 	// remove . from before @? or +<suffix?
 	return strings.TrimSpace(strings.ToLower(email))


### PR DESCRIPTION
### Motivation
- Provide a way for users to turn a recipe Q&A thread into an updated recipe without mutating the shopping list. 
- Ensure regenerated recipes remain linked to the previous iteration and replace the user's saved recipe so history is preserved. 

### Description
- Added a single-recipe regeneration handler at `POST /recipe/{hash}/regenerate` implemented in `internal/recipes/server.go` as `handleRegenerateSingleRecipe`. 
- Plumbed regeneration through the generator by adding `RegenerateRecipe` to the `generator` interface and `generatorService` with an adapter to `aiClient.Regenerate`, and added a mock implementation in `internal/recipes/mock.go`. 
- The handler requires an existing question thread and uses the latest thread response ID to call `RegenerateRecipe`, then sets `OriginHash` and `ParentHash`, saves the regenerated recipe via `SaveRecipe`, and updates the user's saved recipe using a new `Storage.ReplaceRecipe` method in `internal/users/storage.go`. 
- Added a signed-in UI action to `internal/templates/recipe.html` (`Try again, chef`) that appears when a recipe has a Q&A thread and documents that the shopping list will remain unchanged. 
- Added unit test `TestHandleRegenerateSingleRecipe_ReplacesSavedRecipeWithoutChangingShoppingList` in `internal/recipes/server_test.go` covering replacement of a saved recipe, parent/origin linkage, and leaving the shopping list intact. 

### Testing
- Ran `go test ./internal/recipes ./internal/users` and the test suite passed. 
- Ran `go test ./...` and the repository test suite passed. 
- Confirmed the new test `TestHandleRegenerateSingleRecipe_ReplacesSavedRecipeWithoutChangingShoppingList` passes. 
- `./tailwind/generate.sh` could not be executed in this environment because Docker is not available. 
- `golangci-lint run ./...` could not be executed due to the environment's `golangci-lint` being built with Go 1.24 while the repo targets Go 1.26.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3890afae9c8329b541f6fb063f18ba)