### PR TITLE
Enforce per-attempt timeout and add structured retry logging for Whole Foods client

### DIFF
--- a/internal/wholefoods/client.go
+++ b/internal/wholefoods/client.go
@@ -20,8 +20,8 @@ const (
 	// DefaultBaseURL is the public Whole Foods Market website origin.
 	DefaultBaseURL               = "https://www.wholefoodsmarket.com"
 	defaultCategoryLimit         = 60
-	defaultCategoryTimeout       = 20 * time.Second
-	defaultRequestAttemptTimeout = 5 * time.Second
+	defaultCategoryTimeout       = 2 * time.Minute
+	defaultRequestAttemptTimeout = 10 * time.Second
 )
 
 // client calls the public Whole Foods category products endpoint.
@@ -255,17 +255,17 @@ func withWholeFoodsRetries(baseClient *http.Client) *http.Client {
 		baseClient = http.DefaultClient
 	}
 	retryHTTPClient := *baseClient
-	if retryHTTPClient.Timeout == 0 {
+	if retryHTTPClient.Timeout == 0 || retryHTTPClient.Timeout > defaultRequestAttemptTimeout {
 		retryHTTPClient.Timeout = defaultRequestAttemptTimeout
 	}
-
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient = &retryHTTPClient
-	retryClient.Logger = wholeFoodsRetryLogger{}
+	retryClient.Logger = nil
 	retryClient.RetryMax = 2
 	retryClient.RetryWaitMin = 100 * time.Millisecond
 	retryClient.RetryWaitMax = time.Second
 	retryClient.CheckRetry = wholeFoodsRetryPolicy
+	retryClient.RequestLogHook = wholeFoodsRetryLogHook
 	retryClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
 	return retryClient.StandardClient()
 }
@@ -287,8 +287,36 @@ func wholeFoodsRetryPolicy(ctx context.Context, resp *http.Response, err error) 
 	return resp.StatusCode >= http.StatusInternalServerError && resp.StatusCode <= 599, nil
 }
 
-type wholeFoodsRetryLogger struct{}
+func wholeFoodsRetryLogHook(_ retryablehttp.Logger, req *http.Request, attempt int) {
+	if attempt == 0 || req == nil {
+		return
+	}
 
-func (wholeFoodsRetryLogger) Printf(format string, args ...any) {
-	slog.Info(fmt.Sprintf(format, args...), "source", "wholefoods-retryablehttp")
+	slog.InfoContext(req.Context(), "Retrying Whole Foods request", wholeFoodsRequestLogAttrs(req, "attempt", attempt+1)...)
+}
+
+func wholeFoodsRequestLogAttrs(req *http.Request, extra ...any) []any {
+	attrs := []any{
+		"source", "wholefoods-retryablehttp",
+	}
+	attrs = append(attrs, extra...)
+	if req == nil || req.URL == nil {
+		return attrs
+	}
+
+	attrs = append(attrs, "url", req.URL.String())
+	if category := strings.TrimPrefix(req.URL.Path, "/api/products/category/"); category != req.URL.Path && category != "" {
+		if unescaped, err := url.PathUnescape(category); err == nil {
+			category = unescaped
+		}
+		attrs = append(attrs, "category", category)
+	}
+	query := req.URL.Query()
+	if store := query.Get("store"); store != "" {
+		attrs = append(attrs, "store", store)
+	}
+	if offset := query.Get("offset"); offset != "" {
+		attrs = append(attrs, "offset", offset)
+	}
+	return attrs
 }

--- a/internal/wholefoods/client_test.go
+++ b/internal/wholefoods/client_test.go
@@ -1,10 +1,12 @@
 package wholefoods
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -179,6 +181,124 @@ func TestCategory_RetriesRequestAttemptTimeoutWithinCategoryBudget(t *testing.T)
 	}
 }
 
+func TestCategory_RetriesLatePageAttemptTimeoutWithinCategoryBudget(t *testing.T) {
+	t.Parallel()
+
+	attemptsByOffset := map[string]int{}
+	client := NewClientWithBaseURL("https://example.com", &http.Client{
+		Transport: wholeFoodsRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			offset := r.URL.Query().Get("offset")
+			attemptsByOffset[offset]++
+			if offset == strconv.Itoa(defaultCategoryLimit*2) && attemptsByOffset[offset] == 1 {
+				return nil, wholeFoodsTimeoutError{}
+			}
+
+			pageSize := defaultCategoryLimit
+			if offset == strconv.Itoa(defaultCategoryLimit*2) {
+				pageSize = 1
+			}
+
+			results := make([]product, 0, pageSize)
+			for i := 0; i < pageSize; i++ {
+				results = append(results, product{
+					Name:  fmt.Sprintf("Product %s-%d", offset, i),
+					Slug:  fmt.Sprintf("product-%s-%d", offset, i),
+					Brand: "Whole Foods Market",
+					Store: 10216,
+				})
+			}
+
+			payload, err := json.Marshal(categoryResponse{Results: results})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body:    io.NopCloser(strings.NewReader(string(payload))),
+				Request: r,
+			}, nil
+		}),
+	})
+
+	resp, err := client.Category(context.Background(), "fresh-vegetables", "10153")
+	if err != nil {
+		t.Fatalf("Category returned error: %v", err)
+	}
+	if got, want := attemptsByOffset[strconv.Itoa(defaultCategoryLimit*2)], 2; got != want {
+		t.Fatalf("unexpected late page attempts: got %d want %d", got, want)
+	}
+	if got, want := len(resp), defaultCategoryLimit*2+1; got != want {
+		t.Fatalf("unexpected result count: got %d want %d", got, want)
+	}
+}
+
+func TestCategory_LogsRetryAttemptsWithCategoryStoreAndOffset(t *testing.T) {
+	var logBuf bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	attemptsByOffset := map[string]int{}
+	client := NewClientWithBaseURL("https://example.com", &http.Client{
+		Transport: wholeFoodsRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			offset := r.URL.Query().Get("offset")
+			attemptsByOffset[offset]++
+			if offset == strconv.Itoa(defaultCategoryLimit*2) && attemptsByOffset[offset] == 1 {
+				return nil, wholeFoodsTimeoutError{}
+			}
+
+			pageSize := defaultCategoryLimit
+			if offset == strconv.Itoa(defaultCategoryLimit*2) {
+				pageSize = 1
+			}
+
+			results := make([]product, 0, pageSize)
+			for i := 0; i < pageSize; i++ {
+				results = append(results, product{
+					Name:  fmt.Sprintf("Product %s-%d", offset, i),
+					Slug:  fmt.Sprintf("product-%s-%d", offset, i),
+					Brand: "Whole Foods Market",
+					Store: 10216,
+				})
+			}
+
+			payload, err := json.Marshal(categoryResponse{Results: results})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(string(payload))),
+				Request:    r,
+			}, nil
+		}),
+	})
+
+	_, err := client.Category(context.Background(), "fresh-vegetables", "10153")
+	if err != nil {
+		t.Fatalf("Category returned error: %v", err)
+	}
+
+	logs := logBuf.String()
+	for _, want := range []string{
+		"Retrying Whole Foods request",
+		"category=fresh-vegetables",
+		"store=10153",
+		"offset=120",
+		"attempt=2",
+	} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("retry log missing %q in logs:\n%s", want, logs)
+		}
+	}
+}
+
 func TestCategory_PaginatesUntilShortPage(t *testing.T) {
 	t.Parallel()
 
@@ -326,4 +446,18 @@ func (f wholeFoodsRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, err
 
 func ioNopCloserString(body string) io.ReadCloser {
 	return io.NopCloser(strings.NewReader(body))
+}
+
+type wholeFoodsTimeoutError struct{}
+
+func (wholeFoodsTimeoutError) Error() string {
+	return "timeout awaiting headers"
+}
+
+func (wholeFoodsTimeoutError) Timeout() bool {
+	return true
+}
+
+func (wholeFoodsTimeoutError) Temporary() bool {
+	return true
 }


### PR DESCRIPTION
### Motivation

- Bound per-request retry attempt duration and increase category budget to reduce spurious failures when pages are slow by increasing timeouts. 
- Replace the generic retry logger with a structured `slog`-based hook to surface retry context (category, store, offset, attempt) for observability. 

### Description

- Increased `defaultCategoryTimeout` from `20s` to `2m` and `defaultRequestAttemptTimeout` from `5s` to `10s` to give category walks more time. 
- Ensure the retry HTTP client's timeout is set to `defaultRequestAttemptTimeout` when the base client timeout is unset or longer than the default by changing the check in `withWholeFoodsRetries`. 
- Remove the custom `wholeFoodsRetryLogger` and wire `retryablehttp.RequestLogHook` to `wholeFoodsRetryLogHook`, which logs retry attempts via `slog.InfoContext`. 
- Add `wholeFoodsRequestLogAttrs` to build structured attributes including `url`, `category`, `store`, `offset`, and allow passing an `attempt` attribute; add tests and a `wholeFoodsTimeoutError` test helper to exercise late-page retries and logging. 

### Testing

- Ran unit tests for the package with `go test ./internal/wholefoods -run TestCategory -v` and the suite passed. 
- New tests `TestCategory_RetriesLatePageAttemptTimeoutWithinCategoryBudget` and `TestCategory_LogsRetryAttemptsWithCategoryStoreAndOffset` were executed and passed. 
- Existing pagination and decode tests such as `TestCategory_PaginatesUntilShortPage` and `TestCategory_BuildsRequestAndDecodesFixture` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39511e6c7083299acec4d4f3059a24)