### PR TITLE
[codex] convert aldi query tests to testify

### DIFF
--- a/internal/aldi/query/client_test.go
+++ b/internal/aldi/query/client_test.go
@@ -359,7 +359,7 @@ func TestProductsHydratesItemIDsUpToLimit(t *testing.T) {
 						}
 					}`), nil
 				default:
-					t.Fatalf("unexpected operation: %s", r.URL.Query().Get("operationName"))
+					require.FailNowf(t, "unexpected operation", "operation: %s", r.URL.Query().Get("operationName"))
 					return nil, nil
 				}
 			}),
@@ -419,7 +419,7 @@ func TestProductsReusesGeneratedZoneIDForStore(t *testing.T) {
 						}
 					}`), nil
 				default:
-					t.Fatalf("unexpected operation: %s", r.URL.Query().Get("operationName"))
+					require.FailNowf(t, "unexpected operation", "operation: %s", r.URL.Query().Get("operationName"))
 					return nil, nil
 				}
 			}),
@@ -459,7 +459,7 @@ func TestCollectionProductsValidatesRequiredFields(t *testing.T) {
 	client := NewClient(ClientConfig{
 		HTTPClient: &http.Client{
 			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-				t.Fatal("unexpected HTTP call")
+				require.FailNow(t, "unexpected HTTP call")
 				return nil, nil
 			}),
 		},


### PR DESCRIPTION
## What changed
- Converted remaining internal/aldi/query test failures to testify require helpers.

## Why
- Keeps query package tests aligned with the repository preference for testify assert/require.

## Verification
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-modcache go test ./internal/aldi/query