### PR TITLE
Add recipe model critique benchmark command

### DIFF
--- a/cmd/recipebench/main.go
+++ b/cmd/recipebench/main.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"careme/internal/ai"
+	"careme/internal/cache"
+	"careme/internal/config"
+	ingredientgrading "careme/internal/ingredients/grading"
+	"careme/internal/locations"
+	"careme/internal/recipes"
+	"careme/internal/recipes/critique"
+	"careme/internal/recipes/prompts"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+const mealCount = 10
+
+type recordingCritiquer struct {
+	base interface {
+		CritiqueRecipe(context.Context, ai.Recipe) (*ai.RecipeCritique, error)
+		CritiqueRecipeInBackground(context.Context, ai.Recipe)
+	}
+	mu     sync.Mutex
+	scores map[string]int
+}
+
+func newRecordingCritiquer(base interface {
+	CritiqueRecipe(context.Context, ai.Recipe) (*ai.RecipeCritique, error)
+	CritiqueRecipeInBackground(context.Context, ai.Recipe)
+}) *recordingCritiquer {
+	return &recordingCritiquer{base: base, scores: map[string]int{}}
+}
+
+func (r *recordingCritiquer) CritiqueRecipe(ctx context.Context, recipe ai.Recipe) (*ai.RecipeCritique, error) {
+	c, err := r.base.CritiqueRecipe(ctx, recipe)
+	if err != nil {
+		return nil, err
+	}
+	r.record(recipe, c)
+	return c, nil
+}
+
+func (r *recordingCritiquer) CritiqueRecipeInBackground(ctx context.Context, recipe ai.Recipe) {
+	c, err := r.base.CritiqueRecipe(ctx, recipe)
+	if err != nil {
+		return
+	}
+	r.record(recipe, c)
+}
+
+func (r *recordingCritiquer) record(recipe ai.Recipe, c *ai.RecipeCritique) {
+	if c == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.scores[recipe.ComputeHash()] = c.OverallScore
+}
+
+func (r *recordingCritiquer) score(recipe ai.Recipe) (int, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	score, ok := r.scores[recipe.ComputeHash()]
+	return score, ok
+}
+
+type modelResult struct {
+	model   string
+	recipes []ai.Recipe
+	scores  []int
+}
+
+func main() {
+	if err := run(context.Background(), os.Args[1:], os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context, args []string, out io.Writer) error {
+	var storeID, modelsFlag, instructions string
+	fs := flag.NewFlagSet("recipebench", flag.ContinueOnError)
+	fs.SetOutput(out)
+	fs.StringVar(&storeID, "store", "", "store/location ID to generate recipes for")
+	fs.StringVar(&modelsFlag, "models", "gpt-5.5,gpt-5.4", "comma-separated recipe models to compare")
+	fs.StringVar(&instructions, "instructions", "", "extra cooking notes, like make it vegetarian")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	storeID = strings.TrimSpace(storeID)
+	if storeID == "" {
+		return errors.New("must provide -store")
+	}
+	models := splitModels(modelsFlag)
+	if len(models) != 2 {
+		return fmt.Errorf("must provide exactly two models, got %d", len(models))
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load configuration: %w", err)
+	}
+	cacheStore, err := newCache(cfg)
+	if err != nil {
+		return err
+	}
+	locStore, err := locations.New(cfg, cacheStore, locations.LoadCentroids())
+	if err != nil {
+		return fmt.Errorf("create location store: %w", err)
+	}
+	store, err := locStore.GetLocationByID(ctx, storeID)
+	if err != nil {
+		return fmt.Errorf("load store %s: %w", storeID, err)
+	}
+	date, err := recipes.StoreToDate(ctx, time.Now(), store)
+	if err != nil {
+		return fmt.Errorf("resolve store date: %w", err)
+	}
+
+	results := make([]modelResult, 0, len(models))
+	for _, model := range models {
+		result, err := runModel(ctx, cfg, cacheStore, *store, date, model, instructions)
+		if err != nil {
+			return err
+		}
+		results = append(results, result)
+	}
+	return writeReport(out, store, date, results)
+}
+
+func splitModels(modelsFlag string) []string {
+	var models []string
+	for _, model := range strings.Split(modelsFlag, ",") {
+		if model = strings.TrimSpace(model); model != "" {
+			models = append(models, model)
+		}
+	}
+	return models
+}
+
+func newCache(cfg *config.Config) (cache.ListCache, error) {
+	if cfg.Mocks.Enable {
+		return cache.NewFileCache("recipes"), nil
+	}
+	cacheStore, err := cache.MakeCache()
+	if err != nil {
+		return nil, fmt.Errorf("create cache: %w", err)
+	}
+	return cacheStore, nil
+}
+
+func runModel(ctx context.Context, cfg *config.Config, cacheStore cache.ListCache, store locations.Location, date time.Time, model, instructions string) (modelResult, error) {
+	httpClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	grader := ingredientgrading.NewManager(cfg, cacheStore, httpClient)
+	staples, err := recipes.NewCachedStaplesService(cfg, cacheStore, grader)
+	if err != nil {
+		return modelResult{}, fmt.Errorf("create staples service: %w", err)
+	}
+	var baseCritiquer interface {
+		CritiqueRecipe(context.Context, ai.Recipe) (*ai.RecipeCritique, error)
+		CritiqueRecipeInBackground(context.Context, ai.Recipe)
+	}
+	baseCritiquer = critique.NewManager(cfg, cacheStore, httpClient)
+	if cfg.Mocks.Enable {
+		baseCritiquer = critique.NewMock(cacheStore)
+	}
+	recorder := newRecordingCritiquer(baseCritiquer)
+	generator, err := recipes.NewGenerator(ai.NewClient(cfg.AI.APIKey, model, httpClient, prompts.NewCacheRecorder(cacheStore)), recorder, staples, recipes.StatusStore(cacheStore), recipes.IO(cacheStore))
+	if err != nil {
+		return modelResult{}, err
+	}
+	params := recipes.DefaultParams(&store, date)
+	params.Instructions = instructions
+	params.Directive = fmt.Sprintf("Generate %d recipes for model comparison.", mealCount)
+	params.Count = mealCount
+	shoppingList, err := generator.GenerateRecipes(ctx, params)
+	if err != nil {
+		return modelResult{}, fmt.Errorf("generate recipes with %s: %w", model, err)
+	}
+	result := modelResult{model: model, recipes: shoppingList.Recipes}
+	for _, recipe := range shoppingList.Recipes {
+		if score, ok := recorder.score(recipe); ok {
+			result.scores = append(result.scores, score)
+		}
+	}
+	return result, nil
+}
+
+func writeReport(w io.Writer, store *locations.Location, date time.Time, results []modelResult) error {
+	if _, err := fmt.Fprintf(w, "Recipe model critique benchmark for %s (%s) on %s\n\n", store.Name, store.ID, date.Format("2006-01-02")); err != nil {
+		return err
+	}
+	for _, result := range results {
+		if _, err := fmt.Fprintf(w, "Model: %s\nRecipes: %d\nAverage critique score: %.2f\n", result.model, len(result.recipes), average(result.scores)); err != nil {
+			return err
+		}
+		for i, recipe := range result.recipes {
+			score := "missing"
+			if i < len(result.scores) {
+				score = fmt.Sprintf("%d", result.scores[i])
+			}
+			if _, err := fmt.Fprintf(w, "- %s: %s\n", recipe.Title, score); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func average(scores []int) float64 {
+	if len(scores) == 0 {
+		return 0
+	}
+	var sum int
+	for _, score := range scores {
+		sum += score
+	}
+	return float64(sum) / float64(len(scores))
+}

--- a/cmd/recipebench/main.go
+++ b/cmd/recipebench/main.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"careme/internal/ai"
@@ -18,6 +17,7 @@ import (
 	"careme/internal/config"
 	ingredientgrading "careme/internal/ingredients/grading"
 	"careme/internal/locations"
+	"careme/internal/parallelism"
 	"careme/internal/recipes"
 	"careme/internal/recipes/critique"
 	"careme/internal/recipes/prompts"
@@ -25,61 +25,25 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-const mealCount = 10
+const (
+	mealCount                  = 10
+	defaultCritiqueModel       = "gemini-3.1-pro-preview"
+	gemini35FlashCritiqueModel = "gemini-3.5-flash"
+)
 
-type recordingCritiquer struct {
-	base interface {
-		CritiqueRecipe(context.Context, ai.Recipe) (*ai.RecipeCritique, error)
-		CritiqueRecipeInBackground(context.Context, ai.Recipe)
-	}
-	mu     sync.Mutex
-	scores map[string]int
-}
-
-func newRecordingCritiquer(base interface {
+type recipeCritiquer interface {
 	CritiqueRecipe(context.Context, ai.Recipe) (*ai.RecipeCritique, error)
+}
+
+type generationCritiquer interface {
+	recipeCritiquer
 	CritiqueRecipeInBackground(context.Context, ai.Recipe)
-}) *recordingCritiquer {
-	return &recordingCritiquer{base: base, scores: map[string]int{}}
-}
-
-func (r *recordingCritiquer) CritiqueRecipe(ctx context.Context, recipe ai.Recipe) (*ai.RecipeCritique, error) {
-	c, err := r.base.CritiqueRecipe(ctx, recipe)
-	if err != nil {
-		return nil, err
-	}
-	r.record(recipe, c)
-	return c, nil
-}
-
-func (r *recordingCritiquer) CritiqueRecipeInBackground(ctx context.Context, recipe ai.Recipe) {
-	c, err := r.base.CritiqueRecipe(ctx, recipe)
-	if err != nil {
-		return
-	}
-	r.record(recipe, c)
-}
-
-func (r *recordingCritiquer) record(recipe ai.Recipe, c *ai.RecipeCritique) {
-	if c == nil {
-		return
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.scores[recipe.ComputeHash()] = c.OverallScore
-}
-
-func (r *recordingCritiquer) score(recipe ai.Recipe) (int, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	score, ok := r.scores[recipe.ComputeHash()]
-	return score, ok
 }
 
 type modelResult struct {
-	model   string
-	recipes []ai.Recipe
-	scores  []int
+	model          string
+	recipes        []ai.Recipe
+	critiqueScores map[string][]int
 }
 
 func main() {
@@ -89,11 +53,12 @@ func main() {
 }
 
 func run(ctx context.Context, args []string, out io.Writer) error {
-	var storeID, modelsFlag, instructions string
+	var storeID, modelsFlag, critiqueModelsFlag, instructions string
 	fs := flag.NewFlagSet("recipebench", flag.ContinueOnError)
 	fs.SetOutput(out)
 	fs.StringVar(&storeID, "store", "", "store/location ID to generate recipes for")
 	fs.StringVar(&modelsFlag, "models", "gpt-5.5,gpt-5.4", "comma-separated recipe models to compare")
+	fs.StringVar(&critiqueModelsFlag, "critique-models", defaultCritiqueModel+","+gemini35FlashCritiqueModel, "comma-separated Gemini critique models to score each recipe with")
 	fs.StringVar(&instructions, "instructions", "", "extra cooking notes, like make it vegetarian")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -102,9 +67,13 @@ func run(ctx context.Context, args []string, out io.Writer) error {
 	if storeID == "" {
 		return errors.New("must provide -store")
 	}
-	models := splitModels(modelsFlag)
-	if len(models) != 2 {
-		return fmt.Errorf("must provide exactly two models, got %d", len(models))
+	recipeModels := splitCSV(modelsFlag)
+	if len(recipeModels) != 2 {
+		return fmt.Errorf("must provide exactly two recipe models, got %d", len(recipeModels))
+	}
+	critiqueModels := splitCSV(critiqueModelsFlag)
+	if len(critiqueModels) == 0 {
+		return errors.New("must provide at least one -critique-models value")
 	}
 
 	cfg, err := config.Load()
@@ -128,25 +97,25 @@ func run(ctx context.Context, args []string, out io.Writer) error {
 		return fmt.Errorf("resolve store date: %w", err)
 	}
 
-	results := make([]modelResult, 0, len(models))
-	for _, model := range models {
-		result, err := runModel(ctx, cfg, cacheStore, *store, date, model, instructions)
+	results := make([]modelResult, 0, len(recipeModels))
+	for _, model := range recipeModels {
+		result, err := runModel(ctx, cfg, cacheStore, *store, date, model, critiqueModels, instructions)
 		if err != nil {
 			return err
 		}
 		results = append(results, result)
 	}
-	return writeReport(out, store, date, results)
+	return writeReport(out, store, date, critiqueModels, results)
 }
 
-func splitModels(modelsFlag string) []string {
-	var models []string
-	for _, model := range strings.Split(modelsFlag, ",") {
-		if model = strings.TrimSpace(model); model != "" {
-			models = append(models, model)
+func splitCSV(value string) []string {
+	var values []string
+	for _, part := range strings.Split(value, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			values = append(values, part)
 		}
 	}
-	return models
+	return values
 }
 
 func newCache(cfg *config.Config) (cache.ListCache, error) {
@@ -160,23 +129,14 @@ func newCache(cfg *config.Config) (cache.ListCache, error) {
 	return cacheStore, nil
 }
 
-func runModel(ctx context.Context, cfg *config.Config, cacheStore cache.ListCache, store locations.Location, date time.Time, model, instructions string) (modelResult, error) {
+func runModel(ctx context.Context, cfg *config.Config, cacheStore cache.ListCache, store locations.Location, date time.Time, model string, critiqueModels []string, instructions string) (modelResult, error) {
 	httpClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 	grader := ingredientgrading.NewManager(cfg, cacheStore, httpClient)
 	staples, err := recipes.NewCachedStaplesService(cfg, cacheStore, grader)
 	if err != nil {
 		return modelResult{}, fmt.Errorf("create staples service: %w", err)
 	}
-	var baseCritiquer interface {
-		CritiqueRecipe(context.Context, ai.Recipe) (*ai.RecipeCritique, error)
-		CritiqueRecipeInBackground(context.Context, ai.Recipe)
-	}
-	baseCritiquer = critique.NewManager(cfg, cacheStore, httpClient)
-	if cfg.Mocks.Enable {
-		baseCritiquer = critique.NewMock(cacheStore)
-	}
-	recorder := newRecordingCritiquer(baseCritiquer)
-	generator, err := recipes.NewGenerator(ai.NewClient(cfg.AI.APIKey, model, httpClient, prompts.NewCacheRecorder(cacheStore)), recorder, staples, recipes.StatusStore(cacheStore), recipes.IO(cacheStore))
+	generator, err := recipes.NewGenerator(ai.NewClient(cfg.AI.APIKey, model, httpClient, prompts.NewCacheRecorder(cacheStore)), generationCritiquerForConfig(cfg, cacheStore, httpClient), staples, recipes.StatusStore(cacheStore), recipes.IO(cacheStore))
 	if err != nil {
 		return modelResult{}, err
 	}
@@ -188,29 +148,82 @@ func runModel(ctx context.Context, cfg *config.Config, cacheStore cache.ListCach
 	if err != nil {
 		return modelResult{}, fmt.Errorf("generate recipes with %s: %w", model, err)
 	}
-	result := modelResult{model: model, recipes: shoppingList.Recipes}
-	for _, recipe := range shoppingList.Recipes {
-		if score, ok := recorder.score(recipe); ok {
-			result.scores = append(result.scores, score)
-		}
+	scores, err := critiqueRecipes(ctx, cfg, httpClient, shoppingList.Recipes, critiqueModels)
+	if err != nil {
+		return modelResult{}, err
 	}
-	return result, nil
+	return modelResult{model: model, recipes: shoppingList.Recipes, critiqueScores: scores}, nil
 }
 
-func writeReport(w io.Writer, store *locations.Location, date time.Time, results []modelResult) error {
-	if _, err := fmt.Fprintf(w, "Recipe model critique benchmark for %s (%s) on %s\n\n", store.Name, store.ID, date.Format("2006-01-02")); err != nil {
+func generationCritiquerForConfig(cfg *config.Config, cacheStore cache.ListCache, httpClient *http.Client) generationCritiquer {
+	if cfg.Mocks.Enable {
+		return critique.NewMock(cacheStore)
+	}
+	return critique.NewManager(cfg, cacheStore, httpClient)
+}
+
+func critiqueRecipes(ctx context.Context, cfg *config.Config, httpClient *http.Client, recipes []ai.Recipe, critiqueModels []string) (map[string][]int, error) {
+	scores := make(map[string][]int, len(critiqueModels))
+	for _, critiqueModel := range critiqueModels {
+		critiquer := recipeCritiquerForModel(cfg, httpClient, critiqueModel)
+		modelScores, err := parallelism.MapWithErrors(recipes, func(recipe ai.Recipe) (int, error) {
+			c, err := critiquer.CritiqueRecipe(ctx, recipe)
+			if err != nil {
+				return 0, fmt.Errorf("critique %q with %s: %w", recipe.Title, critiqueModel, err)
+			}
+			return c.OverallScore, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		scores[critiqueModel] = modelScores
+	}
+	return scores, nil
+}
+
+func recipeCritiquerForModel(cfg *config.Config, httpClient *http.Client, model string) recipeCritiquer {
+	if cfg.Mocks.Enable {
+		return rubberstampCritiquer{}
+	}
+	return ai.NewCritiquer(cfg.Gemini.APIKey, model, httpClient)
+}
+
+type rubberstampCritiquer struct{}
+
+func (rubberstampCritiquer) CritiqueRecipe(context.Context, ai.Recipe) (*ai.RecipeCritique, error) {
+	return &ai.RecipeCritique{OverallScore: 10}, nil
+}
+
+func writeReport(w io.Writer, store *locations.Location, date time.Time, critiqueModels []string, results []modelResult) error {
+	if _, err := fmt.Fprintf(w, "Recipe model critique benchmark for %s (%s) on %s\n", store.Name, store.ID, date.Format("2006-01-02")); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Critique models: %s\n\n", strings.Join(critiqueModels, ", ")); err != nil {
 		return err
 	}
 	for _, result := range results {
-		if _, err := fmt.Fprintf(w, "Model: %s\nRecipes: %d\nAverage critique score: %.2f\n", result.model, len(result.recipes), average(result.scores)); err != nil {
+		if _, err := fmt.Fprintf(w, "Recipe model: %s\nRecipes: %d\n", result.model, len(result.recipes)); err != nil {
 			return err
 		}
-		for i, recipe := range result.recipes {
-			score := "missing"
-			if i < len(result.scores) {
-				score = fmt.Sprintf("%d", result.scores[i])
+		for _, critiqueModel := range critiqueModels {
+			if _, err := fmt.Fprintf(w, "Average %s score: %.2f\n", critiqueModel, average(result.critiqueScores[critiqueModel])); err != nil {
+				return err
 			}
-			if _, err := fmt.Fprintf(w, "- %s: %s\n", recipe.Title, score); err != nil {
+		}
+		for i, recipe := range result.recipes {
+			if _, err := fmt.Fprintf(w, "- %s", recipe.Title); err != nil {
+				return err
+			}
+			for _, critiqueModel := range critiqueModels {
+				score := "missing"
+				if scores := result.critiqueScores[critiqueModel]; i < len(scores) {
+					score = fmt.Sprintf("%d", scores[i])
+				}
+				if _, err := fmt.Fprintf(w, " | %s: %s", critiqueModel, score); err != nil {
+					return err
+				}
+			}
+			if _, err := fmt.Fprintln(w); err != nil {
 				return err
 			}
 		}

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -24,9 +24,11 @@ type client struct {
 	promptRecorder PromptRecorder
 }
 
-// ignoring model for now.
-func NewClient(apiKey, _ string, httpClient *http.Client, promptRecorder PromptRecorder) *client {
-	// ignor model for now.
+func NewClient(apiKey, model string, httpClient *http.Client, promptRecorder PromptRecorder) *client {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = defaultRecipeModel
+	}
 	if promptRecorder == nil {
 		promptRecorder = noopPromptRecorder{}
 	}
@@ -58,7 +60,7 @@ func NewClient(apiKey, _ string, httpClient *http.Client, promptRecorder PromptR
 		recipeSchema:   recipe,
 		wineSchema:     wine,
 		menuSchema:     menu,
-		model:          defaultRecipeModel,
+		model:          model,
 		wineModel:      defaultWineModel,
 		promptRecorder: promptRecorder,
 	}

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -7,12 +7,20 @@ import (
 )
 
 func TestNewClientUsesGPT55ForRecipeFlow(t *testing.T) {
-	client := NewClient("test-key", "ignored", nil, &capturePromptRecorder{})
+	client := NewClient("test-key", "", nil, &capturePromptRecorder{})
 
 	if client.model != "gpt-5.5" {
 		t.Fatalf("expected primary recipe model to be gpt-5.5, got %q", client.model)
 	}
 	if client.wineModel != openai.ChatModelGPT5Mini {
 		t.Fatalf("expected wine model to remain low-cost mini path, got %q", client.wineModel)
+	}
+}
+
+func TestNewClientUsesRequestedRecipeModel(t *testing.T) {
+	client := NewClient("test-key", "gpt-test-model", nil, nil)
+
+	if client.model != "gpt-test-model" {
+		t.Fatalf("expected requested recipe model, got %q", client.model)
 	}
 }

--- a/internal/ai/menu_plan.go
+++ b/internal/ai/menu_plan.go
@@ -17,8 +17,6 @@ import (
 	"github.com/samber/lo"
 )
 
-const recipePlanModel = defaultRecipeModel
-
 type MenuPlan struct {
 	Plans      []RecipePlan `json:"plans"`
 	ResponseID string       `json:"response_id,omitempty" jsonschema:"-"`
@@ -153,7 +151,7 @@ func (c *client) CreateMenuPlan(ctx context.Context, location *locationtypes.Loc
 		return nil, fmt.Errorf("failed to build menu plan messages: %w", err)
 	}
 	params := responses.ResponseNewParams{
-		Model:        recipePlanModel,
+		Model:        c.model,
 		Instructions: openai.String(menuPlanSystemMessage),
 		Input: responses.ResponseNewParamsInputUnion{
 			OfInputItemList: messagesToInput(promptMessages),
@@ -167,7 +165,7 @@ func (c *client) CreateMenuPlan(ctx context.Context, location *locationtypes.Loc
 	}
 	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
 
-	return responseToMenuPlan(ctx, aiCategoryMenu, recipePlanModel, resp)
+	return responseToMenuPlan(ctx, aiCategoryMenu, c.model, resp)
 }
 
 func (c *client) RegenerateMenuPlan(ctx context.Context, instructions []string, previousResponseID string, count int) (*MenuPlan, error) {
@@ -180,7 +178,7 @@ func (c *client) RegenerateMenuPlan(ctx context.Context, instructions []string, 
 	promptMessages := buildRegenerateMenuPlanMessages(instructions, count)
 
 	params := responses.ResponseNewParams{
-		Model:              recipePlanModel,
+		Model:              c.model,
 		PreviousResponseID: openai.String(previousResponseID),
 		// Previous response IDs do not carry over top-level instructions.
 		// https://developers.openai.com/api/docs/guides/text#message-roles-and-instruction-following
@@ -196,7 +194,7 @@ func (c *client) RegenerateMenuPlan(ctx context.Context, instructions []string, 
 		return nil, fmt.Errorf("failed to regenerate menu plan: %w", err)
 	}
 	c.recordRecipePrompt(ctx, resp.ID, params, promptMessages)
-	return responseToMenuPlan(ctx, aiCategoryMenu, recipePlanModel, resp)
+	return responseToMenuPlan(ctx, aiCategoryMenu, c.model, resp)
 }
 
 func responseToMenuPlan(ctx context.Context, category, model string, resp *responses.Response) (*MenuPlan, error) {

--- a/internal/ai/menu_plan_test.go
+++ b/internal/ai/menu_plan_test.go
@@ -137,7 +137,7 @@ func TestCreateMenuPlanRecordsPrompt(t *testing.T) {
 	if recorder.record.ResponseID != "resp-menu-create" {
 		t.Fatalf("unexpected response id: %#v", recorder.record)
 	}
-	if recorder.record.Model != string(recipePlanModel) {
+	if recorder.record.Model != client.model {
 		t.Fatalf("unexpected model: %#v", recorder.record)
 	}
 	if recorder.record.Instructions != strings.TrimSpace(menuPlanSystemMessage) {
@@ -281,7 +281,7 @@ func menuPlanResponseClient(t *testing.T, responseID string) *http.Client {
 					"output_tokens_details": {"reasoning_tokens": 0},
 					"total_tokens": 2
 				}
-			}`, responseID, recipePlanModel))),
+			}`, responseID, defaultRecipeModel))),
 			Request: req,
 		}, nil
 	})}

--- a/internal/recipes/generator.go
+++ b/internal/recipes/generator.go
@@ -191,7 +191,7 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 
 	menuPlanInstructions := []string{p.Directive, p.Instructions}
 
-	menuPlan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, 3)
+	menuPlan, err := g.aiClient.CreateMenuPlan(ctx, p.Location, ingredients, menuPlanInstructions, p.Date, p.LastRecipes, p.recipeCount())
 	if err != nil {
 		return nil, fmt.Errorf("failed to plan recipe variety: %w", err)
 	}
@@ -224,6 +224,13 @@ func (g *generatorService) GenerateRecipes(ctx context.Context, p *generatorPara
 		Recipes: lo.FromSlicePtr(results),
 		Plan:    menuPlan,
 	}, nil
+}
+
+func (p *generatorParams) recipeCount() int {
+	if p.Count > 0 {
+		return p.Count
+	}
+	return 3
 }
 
 func (p *generatorParams) isRegeneration() bool {

--- a/internal/recipes/params.go
+++ b/internal/recipes/params.go
@@ -34,7 +34,8 @@ type generatorParams struct {
 	// per round instuctions
 	Instructions string   `json:"instructions,omitempty"`
 	Directive    string   `json:"directive,omitempty"` // this is the new one that will be used. Can remove GenerationPrompt after a while.
-	LastRecipes  []string `json:"-"`                   // this doesn't get populated until after save.
+	Count        int      `json:"count,omitempty"`
+	LastRecipes  []string `json:"-"` // this doesn't get populated until after save.
 	// UserID         string      `json:"user_id,omitempty"`
 	// ideally this would be a section and we'd fetch titles and other things as needed
 	// as is this records a selectio at the time of a regeneration
@@ -72,6 +73,9 @@ func (g *generatorParams) Hash() string {
 	lo.Must(io.WriteString(fnv, staplesSignatureForLocation(g.Location.ID)))
 	lo.Must(io.WriteString(fnv, g.Instructions)) // rethink this? if they're all in convo should we have one id and ability to walk back?
 	lo.Must(io.WriteString(fnv, g.Directive))
+	if g.Count > 0 {
+		lo.Must(io.WriteString(fnv, fmt.Sprintf("count:%d", g.Count)))
+	}
 	for _, saved := range g.Saved {
 		lo.Must(io.WriteString(fnv, "saved"+saved.ComputeHash()))
 	}


### PR DESCRIPTION
### Motivation
- Provide a repeatable CLI to compare two recipe models end-to-end for the same store inventory by generating 10 recipes per model and collecting critique scores.
- The existing flow defaulted to planning 3 recipes and ignored the requested recipe model in some menu/recipe calls, which prevents fair model-to-model comparisons.

### Description
- Add `cmd/recipebench`, a new command that accepts `-store`, `-models` (two comma-separated models), and `-instructions`, generates a 10-meal menu per model, and reports per-recipe and average critique scores (see `cmd/recipebench/main.go`).
- Add a `recordingCritiquer` wrapper to capture critique scores while reusing the existing critique pipeline or mocks.
- Add `GeneratorParams.Count` and wire it into menu-plan requests so callers can request a custom menu plan size while preserving the default of 3 when unset (`internal/recipes/params.go`, `internal/recipes/generator.go`).
- Honor the requested recipe model end-to-end in the AI client and menu-plan generation/regeneration by accepting a `model` argument in `NewClient` and using `c.model` for menu-plan and recipe requests (`internal/ai/client.go`, `internal/ai/menu_plan.go`).
- Update tests to cover default model behavior and explicit model selection (`internal/ai/client_test.go`, `internal/ai/menu_plan_test.go`).

### Testing
- Attempted `go test ./...` with mocks enabled via `export ENABLE_MOCKS=1`, but the test run was blocked because the environment attempted to download the Go 1.26 toolchain from `proxy.golang.org` and the download was `Forbidden`, so tests could not complete. (failed)
- Attempted `go test ./...` forcing local toolchain via `GOTOOLCHAIN=local`, but the local Go is `1.24.3` while `go.mod` requires Go `1.26`, so tests could not run with the local toolchain either. (failed)
- Ran `golangci-lint run ./...` which failed to load packages for the same toolchain/download issues in this environment; linting could not complete. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41e952cb5883298b41c2f7096f6200)