### PR TITLE
Add "Generate recipes with today's ingredients" link for stale shopping lists

### DIFF
--- a/internal/recipes/html.go
+++ b/internal/recipes/html.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log/slog"
 	"math"
 	"net/http"
 	"regexp"
@@ -131,15 +130,10 @@ func FormatShoppingListHTMLForHash(ctx context.Context, p *generatorParams, l ai
 }
 
 func shoppingListIsOlderThanFreshIngredientsWindow(ctx context.Context, p *generatorParams) bool {
-	if p == nil || p.Location == nil {
-		return false
-	}
 	today, err := StoreToDate(ctx, nowFn(), p.Location)
 	if err != nil {
 		return false
 	}
-	slog.InfoContext(ctx, "comparing dates", "paramsdate", p.Date, "today", today)
-
 	return today.Sub(p.Date) > 24*time.Hour
 }
 

--- a/internal/recipes/html.go
+++ b/internal/recipes/html.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"log/slog"
 	"math"
 	"net/http"
-	"net/url"
 	"regexp"
 	"slices"
 	"strconv"
@@ -89,39 +89,39 @@ func FormatShoppingListHTMLForHash(ctx context.Context, p *generatorParams, l ai
 		}
 	}
 	data := struct {
-		Location                 locations.Location
-		Date                     string
-		MetaDescription          string
-		ClarityScript            template.HTML
-		GoogleTagScript          template.HTML
-		Instructions             string
-		Hash                     string
-		Recipes                  []shoppingRecipeView
-		ShoppingList             []shoppingListGroup
-		HasSavedRecipes          bool
-		Style                    seasons.Style
-		ServerSignedIn           bool
-		User                     *utypes.User
-		AuthReturnTo             string
-		ShowFreshIngredientsLink bool
-		FreshIngredientsURL      string
+		Location             locations.Location
+		Date                 string
+		DateDisplay          string
+		MetaDescription      string
+		ClarityScript        template.HTML
+		GoogleTagScript      template.HTML
+		Instructions         string
+		Hash                 string
+		Recipes              []shoppingRecipeView
+		ShoppingList         []shoppingListGroup
+		HasSavedRecipes      bool
+		Style                seasons.Style
+		ServerSignedIn       bool
+		User                 *utypes.User
+		AuthReturnTo         string
+		UseTodaysIngredients bool
 	}{
-		Location:                 *p.Location,
-		Date:                     p.Date.Format("2006-01-02"),
-		MetaDescription:          shoppingListMetaDescription(l.Recipes, p.Location.Name, p.Date.Format("2006-01-02")),
-		ClarityScript:            templates.ClarityScript(ctx),
-		GoogleTagScript:          templates.GoogleTagScript(),
-		Instructions:             p.Instructions,
-		Hash:                     hash,
-		Recipes:                  recipeViews,
-		ShoppingList:             shoppingListForDisplay(combinedIngredients),
-		HasSavedRecipes:          hasSavedRecipes,
-		Style:                    seasons.GetCurrentStyle(),
-		ServerSignedIn:           serverSignedIn,
-		User:                     currentUser,
-		AuthReturnTo:             "/recipes?h=" + hash,
-		ShowFreshIngredientsLink: shoppingListIsOlderThanFreshIngredientsWindow(ctx, p),
-		FreshIngredientsURL:      freshIngredientsURL(p),
+		Location:             *p.Location,
+		Date:                 p.Date.Format("2006-01-02"),
+		DateDisplay:          p.Date.Format("January 2, 2006"),
+		MetaDescription:      shoppingListMetaDescription(l.Recipes, p.Location.Name, p.Date.Format("2006-01-02")),
+		ClarityScript:        templates.ClarityScript(ctx),
+		GoogleTagScript:      templates.GoogleTagScript(),
+		Instructions:         p.Instructions,
+		Hash:                 hash,
+		Recipes:              recipeViews,
+		ShoppingList:         shoppingListForDisplay(combinedIngredients),
+		HasSavedRecipes:      hasSavedRecipes,
+		Style:                seasons.GetCurrentStyle(),
+		ServerSignedIn:       serverSignedIn,
+		User:                 currentUser,
+		AuthReturnTo:         "/recipes?h=" + hash,
+		UseTodaysIngredients: shoppingListIsOlderThanFreshIngredientsWindow(ctx, p),
 	}
 
 	setTextContent(writer)
@@ -138,15 +138,9 @@ func shoppingListIsOlderThanFreshIngredientsWindow(ctx context.Context, p *gener
 	if err != nil {
 		return false
 	}
-	return today.Sub(p.Date) > 48*time.Hour
-}
+	slog.InfoContext(ctx, "comparing dates", "paramsdate", p.Date, "today", today)
 
-func freshIngredientsURL(p *generatorParams) string {
-	if p == nil || p.Location == nil {
-		return "/recipes"
-	}
-	values := url.Values{"location": []string{p.Location.ID}}
-	return "/recipes?" + values.Encode()
+	return today.Sub(p.Date) > 24*time.Hour
 }
 
 func shoppingListMetaDescription(recipes []ai.Recipe, locationName, date string) string {

--- a/internal/recipes/html.go
+++ b/internal/recipes/html.go
@@ -8,10 +8,12 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"regexp"
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"careme/internal/ai"
@@ -87,41 +89,64 @@ func FormatShoppingListHTMLForHash(ctx context.Context, p *generatorParams, l ai
 		}
 	}
 	data := struct {
-		Location        locations.Location
-		Date            string
-		MetaDescription string
-		ClarityScript   template.HTML
-		GoogleTagScript template.HTML
-		Instructions    string
-		Hash            string
-		Recipes         []shoppingRecipeView
-		ShoppingList    []shoppingListGroup
-		HasSavedRecipes bool
-		Style           seasons.Style
-		ServerSignedIn  bool
-		User            *utypes.User
-		AuthReturnTo    string
+		Location                 locations.Location
+		Date                     string
+		MetaDescription          string
+		ClarityScript            template.HTML
+		GoogleTagScript          template.HTML
+		Instructions             string
+		Hash                     string
+		Recipes                  []shoppingRecipeView
+		ShoppingList             []shoppingListGroup
+		HasSavedRecipes          bool
+		Style                    seasons.Style
+		ServerSignedIn           bool
+		User                     *utypes.User
+		AuthReturnTo             string
+		ShowFreshIngredientsLink bool
+		FreshIngredientsURL      string
 	}{
-		Location:        *p.Location,
-		Date:            p.Date.Format("2006-01-02"),
-		MetaDescription: shoppingListMetaDescription(l.Recipes, p.Location.Name, p.Date.Format("2006-01-02")),
-		ClarityScript:   templates.ClarityScript(ctx),
-		GoogleTagScript: templates.GoogleTagScript(),
-		Instructions:    p.Instructions,
-		Hash:            hash,
-		Recipes:         recipeViews,
-		ShoppingList:    shoppingListForDisplay(combinedIngredients),
-		HasSavedRecipes: hasSavedRecipes,
-		Style:           seasons.GetCurrentStyle(),
-		ServerSignedIn:  serverSignedIn,
-		User:            currentUser,
-		AuthReturnTo:    "/recipes?h=" + hash,
+		Location:                 *p.Location,
+		Date:                     p.Date.Format("2006-01-02"),
+		MetaDescription:          shoppingListMetaDescription(l.Recipes, p.Location.Name, p.Date.Format("2006-01-02")),
+		ClarityScript:            templates.ClarityScript(ctx),
+		GoogleTagScript:          templates.GoogleTagScript(),
+		Instructions:             p.Instructions,
+		Hash:                     hash,
+		Recipes:                  recipeViews,
+		ShoppingList:             shoppingListForDisplay(combinedIngredients),
+		HasSavedRecipes:          hasSavedRecipes,
+		Style:                    seasons.GetCurrentStyle(),
+		ServerSignedIn:           serverSignedIn,
+		User:                     currentUser,
+		AuthReturnTo:             "/recipes?h=" + hash,
+		ShowFreshIngredientsLink: shoppingListIsOlderThanFreshIngredientsWindow(ctx, p),
+		FreshIngredientsURL:      freshIngredientsURL(p),
 	}
 
 	setTextContent(writer)
 	if err := templates.ShoppingList.Execute(writer, data); err != nil {
 		http.Error(writer, "shopping list template error: "+err.Error(), http.StatusInternalServerError)
 	}
+}
+
+func shoppingListIsOlderThanFreshIngredientsWindow(ctx context.Context, p *generatorParams) bool {
+	if p == nil || p.Location == nil {
+		return false
+	}
+	today, err := StoreToDate(ctx, nowFn(), p.Location)
+	if err != nil {
+		return false
+	}
+	return today.Sub(p.Date) > 48*time.Hour
+}
+
+func freshIngredientsURL(p *generatorParams) string {
+	if p == nil || p.Location == nil {
+		return "/recipes"
+	}
+	values := url.Values{"location": []string{p.Location.ID}}
+	return "/recipes?" + values.Encode()
 }
 
 func shoppingListMetaDescription(recipes []ai.Recipe, locationName, date string) string {

--- a/internal/recipes/html_test.go
+++ b/internal/recipes/html_test.go
@@ -144,6 +144,32 @@ func TestFormatShoppingListHTML_ChefNotesUsesDefaultPlaceholderWithoutPreviousIn
 	assert.Contains(t, html, `placeholder="e.g. make it vegetarian"`)
 }
 
+func TestFormatShoppingListHTML_ShowsFreshIngredientsLinkForOldList(t *testing.T) {
+	withNow(t, time.Date(2026, time.January, 15, 18, 0, 0, 0, time.UTC))
+	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St", ZipCode: "98101"}
+	p := DefaultParams(&loc, time.Date(2026, time.January, 12, 0, 0, 0, 0, time.UTC))
+	w := httptest.NewRecorder()
+
+	formatShoppingListHTMLForTest(t.Context(), p, list, true, recipeSelection{}, w)
+
+	html := assertHTTPSuccess(t, w)
+	assert.Contains(t, html, `href="/recipes?location=70000001"`)
+	assert.Contains(t, html, "Generate recipes with today's ingredients")
+	assert.Less(t, strings.Index(html, "Generate recipes with today's ingredients"), strings.Index(html, "Try again, chef"))
+}
+
+func TestFormatShoppingListHTML_HidesFreshIngredientsLinkForRecentList(t *testing.T) {
+	withNow(t, time.Date(2026, time.January, 15, 18, 0, 0, 0, time.UTC))
+	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St", ZipCode: "98101"}
+	p := DefaultParams(&loc, time.Date(2026, time.January, 14, 0, 0, 0, 0, time.UTC))
+	w := httptest.NewRecorder()
+
+	formatShoppingListHTMLForTest(t.Context(), p, list, true, recipeSelection{}, w)
+
+	html := assertHTTPSuccess(t, w)
+	assert.NotContains(t, html, "Generate recipes with today's ingredients")
+}
+
 func TestFormatShoppingListHTML_ShoppingListUsesOnlyAddedRecipes(t *testing.T) {
 	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St"}
 	addedRecipe := ai.Recipe{

--- a/internal/recipes/html_test.go
+++ b/internal/recipes/html_test.go
@@ -144,7 +144,7 @@ func TestFormatShoppingListHTML_ChefNotesUsesDefaultPlaceholderWithoutPreviousIn
 	assert.Contains(t, html, `placeholder="e.g. make it vegetarian"`)
 }
 
-func TestFormatShoppingListHTML_ShowsFreshIngredientsLinkForOldList(t *testing.T) {
+func TestFormatShoppingListHTML_UsesTodaysIngredientsForOldList(t *testing.T) {
 	withNow(t, time.Date(2026, time.January, 15, 18, 0, 0, 0, time.UTC))
 	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St", ZipCode: "98101"}
 	p := DefaultParams(&loc, time.Date(2026, time.January, 12, 0, 0, 0, 0, time.UTC))
@@ -153,21 +153,50 @@ func TestFormatShoppingListHTML_ShowsFreshIngredientsLinkForOldList(t *testing.T
 	formatShoppingListHTMLForTest(t.Context(), p, list, true, recipeSelection{}, w)
 
 	html := assertHTTPSuccess(t, w)
-	assert.Contains(t, html, `href="/recipes?location=70000001"`)
-	assert.Contains(t, html, "Generate recipes with today's ingredients")
-	assert.Less(t, strings.Index(html, "Generate recipes with today's ingredients"), strings.Index(html, "Try again, chef"))
+	assert.Contains(t, html, `method="GET"`)
+	assert.Contains(t, html, `action="/recipes"`)
+	assert.Contains(t, html, `name="location" value="70000001"`)
+	assert.Contains(t, html, `Using ingredients from <span class="font-semibold text-brand-700">January 12, 2026</span>.`)
+	assert.Contains(t, html, "Use today's ingredients")
+	assert.NotContains(t, html, `Chef notes`)
+	assert.NotContains(t, html, `name="instructions"`)
+	assert.NotContains(t, html, "Try again, chef")
+	assert.NotContains(t, html, `Older list`)
+	assert.NotContains(t, html, `/regenerate"`)
 }
 
-func TestFormatShoppingListHTML_HidesFreshIngredientsLinkForRecentList(t *testing.T) {
+func TestFormatShoppingListHTML_UsesRegenerateForRecentList(t *testing.T) {
 	withNow(t, time.Date(2026, time.January, 15, 18, 0, 0, 0, time.UTC))
 	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St", ZipCode: "98101"}
-	p := DefaultParams(&loc, time.Date(2026, time.January, 14, 0, 0, 0, 0, time.UTC))
+	p := DefaultParams(&loc, time.Date(2026, time.January, 15, 0, 0, 0, 0, time.UTC))
 	w := httptest.NewRecorder()
 
 	formatShoppingListHTMLForTest(t.Context(), p, list, true, recipeSelection{}, w)
 
 	html := assertHTTPSuccess(t, w)
-	assert.NotContains(t, html, "Generate recipes with today's ingredients")
+	assert.Contains(t, html, `method="POST"`)
+	assert.Contains(t, html, `/regenerate"`)
+	assert.Contains(t, html, "Try again, chef")
+	assert.NotContains(t, html, "Use today's ingredients")
+	assert.NotContains(t, html, `Older list`)
+	assert.NotContains(t, html, `Using ingredients from`)
+	assert.NotContains(t, html, `January 15, 2026`)
+	assert.NotContains(t, html, `name="location" value="70000001"`)
+}
+
+func TestFormatShoppingListHTML_ShowsLocationWithoutDateWhenFresh(t *testing.T) {
+	loc := locations.Location{ID: "70000001", Name: "Store", Address: "1 Main St"}
+	p := DefaultParams(&loc, time.Date(2026, time.January, 25, 0, 0, 0, 0, time.UTC))
+	w := httptest.NewRecorder()
+
+	formatShoppingListHTMLForTest(t.Context(), p, list, true, recipeSelection{}, w)
+
+	html := assertHTTPSuccess(t, w)
+	assert.Contains(t, html, `Location: <span class="font-semibold text-brand-700">Store</span>`)
+	assert.Contains(t, html, `<span class="text-sm text-ink-500">(1 Main St)</span>`)
+	assert.NotContains(t, html, `Ingredients from`)
+	assert.NotContains(t, html, `Using ingredients from`)
+	assert.NotContains(t, html, `January 25, 2026`)
 }
 
 func TestFormatShoppingListHTML_ShoppingListUsesOnlyAddedRecipes(t *testing.T) {

--- a/internal/templates/shoppinglist.html
+++ b/internal/templates/shoppinglist.html
@@ -48,6 +48,24 @@
         </div>
 
         <div class="p-8">
+          {{if .UseTodaysIngredients}}
+          <form id="regenerateForm"
+                method="GET"
+                action="/recipes">
+            <input type="hidden" name="location" value="{{.Location.ID}}" />
+            <div class="sticky top-3 z-20 -mx-2 px-2 pb-4">
+              <div class="friendly-card-soft flex flex-col gap-3 border border-brand-100 bg-brand-50/80 p-4 shadow-sm backdrop-blur-[2px] sm:flex-row sm:items-center sm:justify-between">
+                <p class="text-sm text-ink-600">
+                  Using ingredients from <span class="font-semibold text-brand-700">{{.DateDisplay}}</span>.
+                </p>
+                <button type="submit"
+                        class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
+                  Use today's ingredients
+                </button>
+              </div>
+            </div>
+          </form>
+          {{else}}
           <form id="regenerateForm"
                 method="POST"
                 action="/recipes/{{.Hash}}/regenerate"
@@ -62,12 +80,6 @@
                        name="instructions"
                        placeholder="{{if .Instructions}}{{.Instructions}}{{else}}e.g. make it vegetarian{{end}}"
                        class="w-full flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-ink-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400" />
-                {{if .ShowFreshIngredientsLink}}
-                <a href="{{.FreshIngredientsURL}}"
-                   class="inline-flex items-center justify-center rounded-lg border border-brand-200 bg-white px-4 py-2.5 text-sm font-semibold text-brand-700 shadow-sm transition hover:bg-brand-50 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
-                  Generate recipes with today's ingredients
-                </a>
-                {{end}}
                 <button type="submit"
                         class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
                   Try again, chef
@@ -75,6 +87,7 @@
               </div>
             </div>
           </form>
+          {{end}}
 
           <div class="mt-8 space-y-8">
             {{range .Recipes}}

--- a/internal/templates/shoppinglist.html
+++ b/internal/templates/shoppinglist.html
@@ -62,6 +62,12 @@
                        name="instructions"
                        placeholder="{{if .Instructions}}{{.Instructions}}{{else}}e.g. make it vegetarian{{end}}"
                        class="w-full flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-ink-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400" />
+                {{if .ShowFreshIngredientsLink}}
+                <a href="{{.FreshIngredientsURL}}"
+                   class="inline-flex items-center justify-center rounded-lg border border-brand-200 bg-white px-4 py-2.5 text-sm font-semibold text-brand-700 shadow-sm transition hover:bg-brand-50 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
+                  Generate recipes with today's ingredients
+                </a>
+                {{end}}
                 <button type="submit"
                         class="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2">
                   Try again, chef


### PR DESCRIPTION
### Motivation
- Users viewing a shopping list that is more than 48 hours old should have an obvious way to regenerate recipes using the store’s current ingredients.

### Description
- Added template state to the shopping-list renderer (`ShowFreshIngredientsLink` and `FreshIngredientsURL`) and implemented `shoppingListIsOlderThanFreshIngredientsWindow` and `freshIngredientsURL` in `internal/recipes/html.go`, including imports for `net/url` and `time`.
- Updated `internal/templates/shoppinglist.html` to render a `Generate recipes with today's ingredients` link above the `Try again, chef` button when the shopping list is stale.
- Added unit tests in `internal/recipes/html_test.go` that assert the fresh-ingredients link is shown for lists older than 48 hours and hidden for recent lists, and that the link appears before the regenerate button.

### Testing
- Ran `go test ./internal/recipes` and the package tests passed.
- Ran `go test ./...` and the full test suite passed.
- Ran `go vet ./...` successfully; `./tailwind/generate.sh` could not run because Docker is not available in this environment.
- `golangci-lint run ./...` was not executed successfully because the installed `golangci-lint` binary was built with Go 1.24 while the repository targets Go 1.26.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4442c5fb9883298dc163088edf471d)