### PR TITLE
Block guest recipe generation when request has no cookies

### DIFF
--- a/internal/guest/shopping_list_cookie.go
+++ b/internal/guest/shopping_list_cookie.go
@@ -1,0 +1,45 @@
+package guest
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ShoppingListCookieName = "careme_guest_shopping_lists"
+	ShoppingListLimit      = 2
+	shoppingListCookieAge  = 90 * 24 * time.Hour
+)
+
+func ShoppingListCount(r *http.Request) (int, bool) {
+	cookie, err := r.Cookie(ShoppingListCookieName)
+	if err != nil {
+		return 0, false
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(cookie.Value))
+	if err != nil || count < 0 {
+		return 0, false
+	}
+	return count, true
+}
+
+func SetShoppingListCount(w http.ResponseWriter, r *http.Request, count int) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     ShoppingListCookieName,
+		Value:    strconv.Itoa(count),
+		Path:     "/",
+		MaxAge:   int(shoppingListCookieAge.Seconds()),
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func EnsureShoppingListCount(w http.ResponseWriter, r *http.Request) {
+	if _, ok := ShoppingListCount(r); ok {
+		return
+	}
+	SetShoppingListCount(w, r, 0)
+}

--- a/internal/guest/shopping_list_cookie.go
+++ b/internal/guest/shopping_list_cookie.go
@@ -9,11 +9,11 @@ import (
 
 const (
 	ShoppingListCookieName = "careme_guest_shopping_lists"
-	ShoppingListLimit      = 2
+	shoppingListLimit      = 2
 	shoppingListCookieAge  = 90 * 24 * time.Hour
 )
 
-func ShoppingListCount(r *http.Request) (int, bool) {
+func shoppingListCount(r *http.Request) (int, bool) {
 	cookie, err := r.Cookie(ShoppingListCookieName)
 	if err != nil {
 		return 0, false
@@ -25,7 +25,7 @@ func ShoppingListCount(r *http.Request) (int, bool) {
 	return count, true
 }
 
-func SetShoppingListCount(w http.ResponseWriter, r *http.Request, count int) {
+func setShoppingListCount(w http.ResponseWriter, r *http.Request, count int) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     ShoppingListCookieName,
 		Value:    strconv.Itoa(count),
@@ -37,9 +37,18 @@ func SetShoppingListCount(w http.ResponseWriter, r *http.Request, count int) {
 	})
 }
 
+func UseShoppingList(w http.ResponseWriter, r *http.Request) bool {
+	count, ok := shoppingListCount(r)
+	if !ok || count >= shoppingListLimit {
+		return false
+	}
+	setShoppingListCount(w, r, count+1)
+	return true
+}
+
 func EnsureShoppingListCount(w http.ResponseWriter, r *http.Request) {
-	if _, ok := ShoppingListCount(r); ok {
+	if _, ok := shoppingListCount(r); ok {
 		return
 	}
-	SetShoppingListCount(w, r, 0)
+	setShoppingListCount(w, r, 0)
 }

--- a/internal/guest/shopping_list_cookie_test.go
+++ b/internal/guest/shopping_list_cookie_test.go
@@ -1,0 +1,46 @@
+package guest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseShoppingList(t *testing.T) {
+	tests := []struct {
+		name            string
+		cookieValue     string
+		wantAllowed     bool
+		wantCookieValue string
+	}{
+		{name: "missing cookie"},
+		{name: "invalid cookie", cookieValue: "wat"},
+		{name: "limit reached", cookieValue: "2"},
+		{name: "first use", cookieValue: "0", wantAllowed: true, wantCookieValue: "1"},
+		{name: "last use", cookieValue: "1", wantAllowed: true, wantCookieValue: "2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/recipes", nil)
+			if tt.cookieValue != "" {
+				req.AddCookie(&http.Cookie{Name: ShoppingListCookieName, Value: tt.cookieValue})
+			}
+			rr := httptest.NewRecorder()
+
+			assert.Equal(t, tt.wantAllowed, UseShoppingList(rr, req))
+
+			cookies := rr.Result().Cookies()
+			if tt.wantCookieValue == "" {
+				assert.Empty(t, cookies)
+				return
+			}
+			require.Len(t, cookies, 1)
+			assert.Equal(t, ShoppingListCookieName, cookies[0].Name)
+			assert.Equal(t, tt.wantCookieValue, cookies[0].Value)
+		})
+	}
+}

--- a/internal/locations/server.go
+++ b/internal/locations/server.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"careme/internal/auth"
+	"careme/internal/guest"
 	"careme/internal/routing"
 	"careme/internal/seasons"
 	"careme/internal/templates"
@@ -97,6 +98,9 @@ func (l *locationServer) Register(mux routing.Registrar, authClient auth.AuthCli
 			slog.InfoContext(ctx, "no zip code provided to /locations")
 			http.Error(w, "provide a zip code with ?zip=12345", http.StatusBadRequest)
 			return
+		}
+		if currentUser == nil {
+			guest.EnsureShoppingListCount(w, r)
 		}
 		var favoriteStore string
 		if currentUser != nil {

--- a/internal/locations/server.go
+++ b/internal/locations/server.go
@@ -91,6 +91,8 @@ func (l *locationServer) Register(mux routing.Registrar, authClient auth.AuthCli
 				slog.ErrorContext(ctx, "failed to get user from request", "error", err)
 				return
 			}
+			// give them a few free samples since they came in through locaitons
+			guest.EnsureShoppingListCount(w, r)
 		}
 
 		zip := r.URL.Query().Get("zip")
@@ -98,9 +100,6 @@ func (l *locationServer) Register(mux routing.Registrar, authClient auth.AuthCli
 			slog.InfoContext(ctx, "no zip code provided to /locations")
 			http.Error(w, "provide a zip code with ?zip=12345", http.StatusBadRequest)
 			return
-		}
-		if currentUser == nil {
-			guest.EnsureShoppingListCount(w, r)
 		}
 		var favoriteStore string
 		if currentUser != nil {

--- a/internal/locations/server_test.go
+++ b/internal/locations/server_test.go
@@ -14,6 +14,7 @@ import (
 	"careme/internal/auth"
 	cachepkg "careme/internal/cache"
 	"careme/internal/config"
+	"careme/internal/guest"
 	"careme/internal/templates"
 )
 
@@ -134,6 +135,100 @@ func TestRequestStoreRejectsSupportedStore(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d; body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+}
+
+func TestLocationsPageSetsGuestShoppingListCookieWhenMissing(t *testing.T) {
+	mustInitLocationTemplates(t)
+
+	client := newFakeLocationClient()
+	client.setListResponse("10001", []Location{{
+		ID:      "12345678",
+		Name:    "Kroger Test",
+		Address: "1 Market St",
+		ZipCode: "10001",
+	}})
+	storage := newTestLocationServer(client)
+	server := NewServer(storage, LoadCentroids(), fakeUserLookup{}, fakeProduceScoreLookup{})
+
+	mux := http.NewServeMux()
+	server.Register(mux, auth.DefaultMock())
+
+	req := httptest.NewRequest(http.MethodGet, "/locations?zip=10001", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	cookie := findResponseCookie(rr, guest.ShoppingListCookieName)
+	if cookie == nil {
+		t.Fatalf("expected %s cookie to be set", guest.ShoppingListCookieName)
+	}
+	if cookie.Value != "0" {
+		t.Fatalf("guest cookie value = %q, want 0", cookie.Value)
+	}
+}
+
+func TestLocationsPagePreservesValidGuestShoppingListCookie(t *testing.T) {
+	mustInitLocationTemplates(t)
+
+	client := newFakeLocationClient()
+	client.setListResponse("10001", []Location{{
+		ID:      "12345678",
+		Name:    "Kroger Test",
+		Address: "1 Market St",
+		ZipCode: "10001",
+	}})
+	storage := newTestLocationServer(client)
+	server := NewServer(storage, LoadCentroids(), fakeUserLookup{}, fakeProduceScoreLookup{})
+
+	mux := http.NewServeMux()
+	server.Register(mux, auth.DefaultMock())
+
+	req := httptest.NewRequest(http.MethodGet, "/locations?zip=10001", nil)
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: "1"})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if cookie := findResponseCookie(rr, guest.ShoppingListCookieName); cookie != nil {
+		t.Fatalf("expected valid guest cookie to be preserved without resetting, got %#v", cookie)
+	}
+}
+
+func TestLocationsPageResetsInvalidGuestShoppingListCookie(t *testing.T) {
+	mustInitLocationTemplates(t)
+
+	client := newFakeLocationClient()
+	client.setListResponse("10001", []Location{{
+		ID:      "12345678",
+		Name:    "Kroger Test",
+		Address: "1 Market St",
+		ZipCode: "10001",
+	}})
+	storage := newTestLocationServer(client)
+	server := NewServer(storage, LoadCentroids(), fakeUserLookup{}, fakeProduceScoreLookup{})
+
+	mux := http.NewServeMux()
+	server.Register(mux, auth.DefaultMock())
+
+	req := httptest.NewRequest(http.MethodGet, "/locations?zip=10001", nil)
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: "wat"})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	cookie := findResponseCookie(rr, guest.ShoppingListCookieName)
+	if cookie == nil {
+		t.Fatalf("expected invalid %s cookie to be reset", guest.ShoppingListCookieName)
+	}
+	if cookie.Value != "0" {
+		t.Fatalf("guest cookie value = %q, want 0", cookie.Value)
 	}
 }
 
@@ -305,4 +400,13 @@ func mustInitLocationTemplates(t *testing.T) {
 	if err := templates.Init(&config.Config{}, "dummyhash"); err != nil {
 		t.Fatalf("failed to init templates: %v", err)
 	}
+}
+
+func findResponseCookie(rr *httptest.ResponseRecorder, name string) *http.Cookie {
+	for _, cookie := range rr.Result().Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+	return nil
 }

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -91,6 +91,10 @@ const (
 	guestShoppingListCookieAge  = 90 * 24 * time.Hour
 )
 
+func hasAnyCookie(r *http.Request) bool {
+	return len(r.Cookies()) > 0
+}
+
 func guestShoppingListCount(r *http.Request) int {
 	cookie, err := r.Cookie(guestShoppingListCookieName)
 	if err != nil {
@@ -1272,6 +1276,11 @@ func (s *server) handleRecipes(w http.ResponseWriter, r *http.Request) {
 		}
 		if _, cacheErr := s.FromCache(ctx, p.Hash()); cacheErr == nil {
 			redirectToHash(w, r, p.Hash(), QueryArgHelp)
+			return
+		}
+		if !hasAnyCookie(r) {
+			slog.InfoContext(ctx, "blocking guest recipe generation without cookies", "user_agent", r.UserAgent())
+			http.Redirect(w, r, signInPath(requestURIOrPath(r)), http.StatusSeeOther)
 			return
 		}
 		if guestShoppingListCount(r) >= guestShoppingListLimit {

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -91,8 +91,9 @@ const (
 	guestShoppingListCookieAge  = 90 * 24 * time.Hour
 )
 
-func hasAnyCookie(r *http.Request) bool {
-	return len(r.Cookies()) > 0
+func hasGuestShoppingListCookie(r *http.Request) bool {
+	cookie, err := r.Cookie(guestShoppingListCookieName)
+	return err == nil && cookie.Value != ""
 }
 
 func guestShoppingListCount(r *http.Request) int {
@@ -1278,8 +1279,8 @@ func (s *server) handleRecipes(w http.ResponseWriter, r *http.Request) {
 			redirectToHash(w, r, p.Hash(), QueryArgHelp)
 			return
 		}
-		if !hasAnyCookie(r) {
-			slog.InfoContext(ctx, "blocking guest recipe generation without cookies", "user_agent", r.UserAgent())
+		if !hasGuestShoppingListCookie(r) {
+			slog.InfoContext(ctx, "blocking guest recipe generation without guest shopping list cookie", "user_agent", r.UserAgent())
 			http.Redirect(w, r, signInPath(requestURIOrPath(r)), http.StatusSeeOther)
 			return
 		}

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -869,8 +869,7 @@ func (s *server) handleRegenerate(w http.ResponseWriter, r *http.Request) {
 	currentUser, err := s.storage.FromRequest(ctx, r, s.clerk)
 	if err != nil {
 		if errors.Is(err, auth.ErrNoSession) {
-			guestShoppingListCount, ok := guest.ShoppingListCount(r)
-			if !ok || guestShoppingListCount >= guest.ShoppingListLimit {
+			if !guest.UseShoppingList(w, r) {
 				if isHTMXRequest(r) {
 					redirectToSignIn(w, r, http.StatusUnauthorized)
 					return
@@ -878,7 +877,6 @@ func (s *server) handleRegenerate(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, signInPath(requestURIOrPath(r)), http.StatusSeeOther)
 				return
 			}
-			guest.SetShoppingListCount(w, r, guestShoppingListCount+1)
 			currentUser = guestUser
 		} else {
 			http.Error(w, "unable to load account", http.StatusInternalServerError)
@@ -1199,6 +1197,9 @@ func (s *server) handleRecipes(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
+		if !signedIn {
+			guest.EnsureShoppingListCount(w, r)
+		}
 		wineRecommendations := make(map[string]*ai.WineSelection, len(slist.Recipes))
 		var wineWG sync.WaitGroup
 		var wineMu sync.Mutex
@@ -1246,17 +1247,11 @@ func (s *server) handleRecipes(w http.ResponseWriter, r *http.Request) {
 			redirectToHash(w, r, p.Hash(), QueryArgHelp)
 			return
 		}
-		guestShoppingListCount, ok := guest.ShoppingListCount(r)
-		if !ok {
-			slog.InfoContext(ctx, "blocking guest recipe generation without guest shopping list cookie", "user_agent", r.UserAgent())
+		if !guest.UseShoppingList(w, r) {
+			slog.InfoContext(ctx, "blocking guest recipe generation", "user_agent", r.UserAgent())
 			http.Redirect(w, r, signInPath(requestURIOrPath(r)), http.StatusSeeOther)
 			return
 		}
-		if guestShoppingListCount >= guest.ShoppingListLimit {
-			http.Redirect(w, r, signInPath(requestURIOrPath(r)), http.StatusSeeOther)
-			return
-		}
-		guest.SetShoppingListCount(w, r, guestShoppingListCount+1)
 		// be careful. Formalize this more?
 		currentUser = guestUser
 	}

--- a/internal/recipes/server.go
+++ b/internal/recipes/server.go
@@ -23,6 +23,7 @@ import (
 	"careme/internal/auth"
 	"careme/internal/cache"
 	"careme/internal/config"
+	"careme/internal/guest"
 	"careme/internal/locations"
 	"careme/internal/recipes/critique"
 	"careme/internal/recipes/feedback"
@@ -83,41 +84,6 @@ func redirectToSignInForSave(w http.ResponseWriter, r *http.Request, shoppingLis
 		w.Header().Set("HX-Redirect", target)
 	}
 	http.Error(w, "must be logged in", status)
-}
-
-const (
-	guestShoppingListCookieName = "careme_guest_shopping_lists"
-	guestShoppingListLimit      = 2
-	guestShoppingListCookieAge  = 90 * 24 * time.Hour
-)
-
-func hasGuestShoppingListCookie(r *http.Request) bool {
-	cookie, err := r.Cookie(guestShoppingListCookieName)
-	return err == nil && cookie.Value != ""
-}
-
-func guestShoppingListCount(r *http.Request) int {
-	cookie, err := r.Cookie(guestShoppingListCookieName)
-	if err != nil {
-		return 0
-	}
-	count, err := strconv.Atoi(strings.TrimSpace(cookie.Value))
-	if err != nil || count < 0 {
-		return 0
-	}
-	return count
-}
-
-func setGuestShoppingListCount(w http.ResponseWriter, r *http.Request, count int) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     guestShoppingListCookieName,
-		Value:    strconv.Itoa(count),
-		Path:     "/",
-		MaxAge:   int(guestShoppingListCookieAge.Seconds()),
-		HttpOnly: true,
-		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteLaxMode,
-	})
 }
 
 type locServer interface {
@@ -903,7 +869,8 @@ func (s *server) handleRegenerate(w http.ResponseWriter, r *http.Request) {
 	currentUser, err := s.storage.FromRequest(ctx, r, s.clerk)
 	if err != nil {
 		if errors.Is(err, auth.ErrNoSession) {
-			if guestShoppingListCount(r) >= guestShoppingListLimit {
+			guestShoppingListCount, ok := guest.ShoppingListCount(r)
+			if !ok || guestShoppingListCount >= guest.ShoppingListLimit {
 				if isHTMXRequest(r) {
 					redirectToSignIn(w, r, http.StatusUnauthorized)
 					return
@@ -911,7 +878,7 @@ func (s *server) handleRegenerate(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, signInPath(requestURIOrPath(r)), http.StatusSeeOther)
 				return
 			}
-			setGuestShoppingListCount(w, r, guestShoppingListCount(r)+1)
+			guest.SetShoppingListCount(w, r, guestShoppingListCount+1)
 			currentUser = guestUser
 		} else {
 			http.Error(w, "unable to load account", http.StatusInternalServerError)
@@ -1279,16 +1246,17 @@ func (s *server) handleRecipes(w http.ResponseWriter, r *http.Request) {
 			redirectToHash(w, r, p.Hash(), QueryArgHelp)
 			return
 		}
-		if !hasGuestShoppingListCookie(r) {
+		guestShoppingListCount, ok := guest.ShoppingListCount(r)
+		if !ok {
 			slog.InfoContext(ctx, "blocking guest recipe generation without guest shopping list cookie", "user_agent", r.UserAgent())
 			http.Redirect(w, r, signInPath(requestURIOrPath(r)), http.StatusSeeOther)
 			return
 		}
-		if guestShoppingListCount(r) >= guestShoppingListLimit {
+		if guestShoppingListCount >= guest.ShoppingListLimit {
 			http.Redirect(w, r, signInPath(requestURIOrPath(r)), http.StatusSeeOther)
 			return
 		}
-		setGuestShoppingListCount(w, r, guestShoppingListCount(r)+1)
+		guest.SetShoppingListCount(w, r, guestShoppingListCount+1)
 		// be careful. Formalize this more?
 		currentUser = guestUser
 	}

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -21,6 +21,7 @@ import (
 	"careme/internal/ai"
 	"careme/internal/auth"
 	"careme/internal/cache"
+	"careme/internal/guest"
 	"careme/internal/locations"
 	"careme/internal/recipes/feedback"
 	"careme/internal/routing"
@@ -349,7 +350,7 @@ func TestHandleRecipes_GuestCanGenerateWhenUnderCookieLimit(t *testing.T) {
 	t.Cleanup(s.Wait)
 
 	req := httptest.NewRequest(http.MethodGet, "/recipes?location=70001001&date=2026-03-06&instructions=make+it+vegetarian", nil)
-	req.AddCookie(&http.Cookie{Name: guestShoppingListCookieName, Value: "1"})
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: "1"})
 	rr := httptest.NewRecorder()
 
 	s.handleRecipes(rr, req)
@@ -368,7 +369,7 @@ func TestHandleRecipes_GuestCanGenerateWhenUnderCookieLimit(t *testing.T) {
 	cookies := rr.Result().Cookies()
 	var guestCookie *http.Cookie
 	for _, cookie := range cookies {
-		if cookie.Name == guestShoppingListCookieName {
+		if cookie.Name == guest.ShoppingListCookieName {
 			guestCookie = cookie
 			break
 		}
@@ -422,6 +423,36 @@ func TestHandleRecipes_GuestRedirectsToSignInWhenGuestShoppingListCookieMissing(
 	}
 }
 
+func TestHandleRecipes_GuestRedirectsToSignInWhenCookieInvalid(t *testing.T) {
+	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
+	generator := &captureKickgenerationGenerator{called: make(chan struct{}, 1)}
+	s := newTestServer(t,
+		withTestCache(cacheStore),
+		withTestClerk(noSessionAuth{}),
+		withTestGenerator(generator),
+		withTestLocationServer(staticLocationLookup{location: &locations.Location{
+			ID:      "70001001",
+			Name:    "Test Store",
+			ZipCode: "94105",
+		}}),
+	)
+	t.Cleanup(s.Wait)
+
+	req := httptest.NewRequest(http.MethodGet, "/recipes?location=70001001&instructions=make+it+vegetarian", nil)
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: "wat"})
+	rr := httptest.NewRecorder()
+
+	s.handleRecipes(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Equal(t, signInPath("/recipes?location=70001001&instructions=make+it+vegetarian"), rr.Header().Get("Location"))
+	select {
+	case <-generator.called:
+		t.Fatal("expected invalid guest cookie not to start generation")
+	default:
+	}
+}
+
 func TestHandleRecipes_GuestRedirectsToSignInWhenCookieLimitReached(t *testing.T) {
 	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
 	s := newTestServer(t,
@@ -435,7 +466,7 @@ func TestHandleRecipes_GuestRedirectsToSignInWhenCookieLimitReached(t *testing.T
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/recipes?location=70001001&instructions=make+it+vegetarian", nil)
-	req.AddCookie(&http.Cookie{Name: guestShoppingListCookieName, Value: strconv.Itoa(guestShoppingListLimit)})
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: strconv.Itoa(guest.ShoppingListLimit)})
 	rr := httptest.NewRecorder()
 
 	s.handleRecipes(rr, req)
@@ -2066,7 +2097,7 @@ func TestHandleRegenerate_GuestUsesRemainingGenerationAndRedirects(t *testing.T)
 	req := httptest.NewRequest(http.MethodPost, "/recipes/"+originHash+"/regenerate", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("HX-Request", "true")
-	req.AddCookie(&http.Cookie{Name: guestShoppingListCookieName, Value: "1"})
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: "1"})
 	req.SetPathValue("hash", originHash)
 	rr := httptest.NewRecorder()
 
@@ -2089,7 +2120,7 @@ func TestHandleRegenerate_GuestUsesRemainingGenerationAndRedirects(t *testing.T)
 	}
 	var guestCookie *http.Cookie
 	for _, cookie := range rr.Result().Cookies() {
-		if cookie.Name == guestShoppingListCookieName {
+		if cookie.Name == guest.ShoppingListCookieName {
 			guestCookie = cookie
 			break
 		}
@@ -2112,6 +2143,27 @@ func TestHandleRegenerate_GuestUsesRemainingGenerationAndRedirects(t *testing.T)
 	require.Empty(t, captured.LastRecipes)
 }
 
+func TestHandleRegenerate_GuestRedirectsToSignInWhenCookieMissing(t *testing.T) {
+	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
+	s := newTestServer(t,
+		withTestCache(cacheStore),
+		withTestClerk(noSessionAuth{}),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/recipes/origin-hash/regenerate", nil)
+	req.SetPathValue("hash", "origin-hash")
+	rr := httptest.NewRecorder()
+
+	s.handleRegenerate(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("expected status %d, got %d", http.StatusSeeOther, rr.Code)
+	}
+	if got, want := rr.Header().Get("Location"), signInPath("/recipes/origin-hash/regenerate"); got != want {
+		t.Fatalf("expected redirect location %q, got %q", want, got)
+	}
+}
+
 func TestHandleRegenerate_GuestRedirectsToSignInWhenCookieLimitReached(t *testing.T) {
 	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
 	s := newTestServer(t,
@@ -2120,7 +2172,7 @@ func TestHandleRegenerate_GuestRedirectsToSignInWhenCookieLimitReached(t *testin
 	)
 
 	req := httptest.NewRequest(http.MethodPost, "/recipes/origin-hash/regenerate", nil)
-	req.AddCookie(&http.Cookie{Name: guestShoppingListCookieName, Value: strconv.Itoa(guestShoppingListLimit)})
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: strconv.Itoa(guest.ShoppingListLimit)})
 	req.SetPathValue("hash", "origin-hash")
 	rr := httptest.NewRecorder()
 
@@ -2143,7 +2195,7 @@ func TestHandleRegenerate_GuestHTMXRedirectsToSignInWhenCookieLimitReached(t *te
 
 	req := httptest.NewRequest(http.MethodPost, "/recipes/origin-hash/regenerate", nil)
 	req.Header.Set("HX-Request", "true")
-	req.AddCookie(&http.Cookie{Name: guestShoppingListCookieName, Value: strconv.Itoa(guestShoppingListLimit)})
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: strconv.Itoa(guest.ShoppingListLimit)})
 	req.SetPathValue("hash", "origin-hash")
 	rr := httptest.NewRecorder()
 

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -390,7 +390,7 @@ func TestHandleRecipes_GuestCanGenerateWhenUnderCookieLimit(t *testing.T) {
 	}
 }
 
-func TestHandleRecipes_GuestRedirectsToSignInWhenNoCookiePresent(t *testing.T) {
+func TestHandleRecipes_GuestRedirectsToSignInWhenGuestShoppingListCookieMissing(t *testing.T) {
 	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
 	generator := &captureKickgenerationGenerator{called: make(chan struct{}, 1)}
 	s := newTestServer(t,
@@ -405,6 +405,7 @@ func TestHandleRecipes_GuestRedirectsToSignInWhenNoCookiePresent(t *testing.T) {
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/recipes?location=70001001&date=2026-03-06&instructions=make+it+vegetarian", nil)
+	req.AddCookie(&http.Cookie{Name: "some_other_cookie", Value: "present"})
 	rr := httptest.NewRecorder()
 
 	s.handleRecipes(rr, req)
@@ -413,7 +414,7 @@ func TestHandleRecipes_GuestRedirectsToSignInWhenNoCookiePresent(t *testing.T) {
 	require.Equal(t, signInPath("/recipes?location=70001001&date=2026-03-06&instructions=make+it+vegetarian"), rr.Header().Get("Location"))
 	select {
 	case <-generator.called:
-		t.Fatal("expected guest generation without cookies not to start")
+		t.Fatal("expected guest generation without guest shopping list cookie not to start")
 	default:
 	}
 	if _, err := s.ParamsFromCache(t.Context(), DefaultParams(&locations.Location{ID: "70001001", Name: "Test Store", ZipCode: "94105"}, time.Date(2026, 3, 6, 0, 0, 0, 0, time.FixedZone("PST", -8*60*60))).Hash()); !errors.Is(err, cache.ErrNotFound) {

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -390,6 +390,37 @@ func TestHandleRecipes_GuestCanGenerateWhenUnderCookieLimit(t *testing.T) {
 	}
 }
 
+func TestHandleRecipes_GuestRedirectsToSignInWhenNoCookiePresent(t *testing.T) {
+	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
+	generator := &captureKickgenerationGenerator{called: make(chan struct{}, 1)}
+	s := newTestServer(t,
+		withTestCache(cacheStore),
+		withTestClerk(noSessionAuth{}),
+		withTestGenerator(generator),
+		withTestLocationServer(staticLocationLookup{location: &locations.Location{
+			ID:      "70001001",
+			Name:    "Test Store",
+			ZipCode: "94105",
+		}}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/recipes?location=70001001&date=2026-03-06&instructions=make+it+vegetarian", nil)
+	rr := httptest.NewRecorder()
+
+	s.handleRecipes(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Equal(t, signInPath("/recipes?location=70001001&date=2026-03-06&instructions=make+it+vegetarian"), rr.Header().Get("Location"))
+	select {
+	case <-generator.called:
+		t.Fatal("expected guest generation without cookies not to start")
+	default:
+	}
+	if _, err := s.ParamsFromCache(t.Context(), DefaultParams(&locations.Location{ID: "70001001", Name: "Test Store", ZipCode: "94105"}, time.Date(2026, 3, 6, 0, 0, 0, 0, time.FixedZone("PST", -8*60*60))).Hash()); !errors.Is(err, cache.ErrNotFound) {
+		t.Fatalf("expected params not to be saved, got %v", err)
+	}
+}
+
 func TestHandleRecipes_GuestRedirectsToSignInWhenCookieLimitReached(t *testing.T) {
 	cacheStore := cache.NewFileCache(filepath.Join(t.TempDir(), "cache"))
 	s := newTestServer(t,

--- a/internal/recipes/server_test.go
+++ b/internal/recipes/server_test.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -198,6 +197,15 @@ func TestHandleRecipes_GuestSeesSaveButtonButNotHideButton(t *testing.T) {
 	s.handleRecipes(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
+	var guestCookie *http.Cookie
+	for _, cookie := range rr.Result().Cookies() {
+		if cookie.Name == guest.ShoppingListCookieName {
+			guestCookie = cookie
+			break
+		}
+	}
+	require.NotNil(t, guestCookie)
+	require.Equal(t, "0", guestCookie.Value)
 	body := rr.Body.String()
 	require.Contains(t, body, `hx-post="/recipe/`+recipe.ComputeHash()+`/save"`)
 	require.Contains(t, body, `Add`)
@@ -466,7 +474,7 @@ func TestHandleRecipes_GuestRedirectsToSignInWhenCookieLimitReached(t *testing.T
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/recipes?location=70001001&instructions=make+it+vegetarian", nil)
-	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: strconv.Itoa(guest.ShoppingListLimit)})
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: "2"})
 	rr := httptest.NewRecorder()
 
 	s.handleRecipes(rr, req)
@@ -2172,7 +2180,7 @@ func TestHandleRegenerate_GuestRedirectsToSignInWhenCookieLimitReached(t *testin
 	)
 
 	req := httptest.NewRequest(http.MethodPost, "/recipes/origin-hash/regenerate", nil)
-	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: strconv.Itoa(guest.ShoppingListLimit)})
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: "2"})
 	req.SetPathValue("hash", "origin-hash")
 	rr := httptest.NewRecorder()
 
@@ -2195,7 +2203,7 @@ func TestHandleRegenerate_GuestHTMXRedirectsToSignInWhenCookieLimitReached(t *te
 
 	req := httptest.NewRequest(http.MethodPost, "/recipes/origin-hash/regenerate", nil)
 	req.Header.Set("HX-Request", "true")
-	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: strconv.Itoa(guest.ShoppingListLimit)})
+	req.AddCookie(&http.Cookie{Name: guest.ShoppingListCookieName, Value: "2"})
 	req.SetPathValue("hash", "origin-hash")
 	rr := httptest.NewRecorder()
 


### PR DESCRIPTION
### Motivation

- Crawlers that do not persist cookies (e.g., SemrushBot) can repeatedly trigger guest recipe generation and exhaust guest quota, so generation should be blocked for cookieless signed-out requests.  

### Description

- Add `hasAnyCookie(r *http.Request) bool` and a guard in `handleRecipes` to reject uncached, signed-out generation requests when the incoming request has no cookies, logging the event and redirecting the client to sign-in.  
- Prevents saving generation params, incrementing guest counters, or kicking off background generation for cookieless requests.  
- Add regression test `TestHandleRecipes_GuestRedirectsToSignInWhenNoCookiePresent` that verifies cookieless guests are redirected, generation is not started, and params are not saved.  
- Files changed: `internal/recipes/server.go` and `internal/recipes/server_test.go`.  

### Testing

- Ran `go test ./internal/recipes -run 'TestHandleRecipes_Guest'` and the guest-related tests passed.  
- Ran full unit suite with `go test ./...` and it completed successfully.  
- Attempted `golangci-lint run ./...` but it could not be executed in this environment due to the installed `golangci-lint` binary being built with an older Go toolchain than the repo target (Go 1.26).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e312a2a8832995323c5943daad5c)