### PR TITLE
dont reuse context

### DIFF
--- a/internal/recipes/critique/manager.go
+++ b/internal/recipes/critique/manager.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"careme/internal/ai"
 	"careme/internal/cache"
@@ -15,7 +16,10 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-const MinimumRecipeScore = 8
+const (
+	MinimumRecipeScore        = 8
+	backgroundCritiqueTimeout = 2 * time.Minute
+)
 
 type recipeCritiquer interface {
 	CritiqueRecipe(ctx context.Context, recipe ai.Recipe) (*ai.RecipeCritique, error)
@@ -65,9 +69,11 @@ func (mc *waitingCritiquer) CritiqueRecipe(ctx context.Context, recipe ai.Recipe
 }
 
 func (mc *waitingCritiquer) CritiqueRecipeInBackground(ctx context.Context, recipe ai.Recipe) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), backgroundCritiqueTimeout)
 	mc.wg.Add(1)
 	go func() {
 		defer mc.wg.Done()
+		defer cancel()
 		_, err := mc.CritiqueRecipe(ctx, recipe)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to critique recipe", "hash", recipe.ComputeHash(), "title", recipe.Title, "error", err)

--- a/internal/recipes/critique/multi_test.go
+++ b/internal/recipes/critique/multi_test.go
@@ -91,6 +91,31 @@ func TestWaitingCritiquerWaitsForBackgroundCritique(t *testing.T) {
 	}
 }
 
+func TestWaitingCritiquerBackgroundCritiqueOutlivesCallerContext(t *testing.T) {
+	t.Parallel()
+
+	base := &contextCapturingCritiquer{
+		contexts: make(chan context.Context, 1),
+		release:  make(chan struct{}),
+	}
+	mc := &waitingCritiquer{critiquer: base}
+	callerCtx, cancelCaller := context.WithCancel(t.Context())
+
+	mc.CritiqueRecipeInBackground(callerCtx, ai.Recipe{Title: "Patient Dinner"})
+	backgroundCtx := <-base.contexts
+	cancelCaller()
+
+	if err := backgroundCtx.Err(); err != nil {
+		t.Fatalf("background context was canceled with caller: %v", err)
+	}
+	if _, ok := backgroundCtx.Deadline(); !ok {
+		t.Fatal("background context has no deadline")
+	}
+
+	close(base.release)
+	mc.Wait()
+}
+
 type blockingCritiquer struct {
 	started chan struct{}
 	release chan struct{}
@@ -104,4 +129,23 @@ func (b *blockingCritiquer) CritiqueRecipe(context.Context, ai.Recipe) (*ai.Reci
 	close(b.started)
 	<-b.release
 	return &ai.RecipeCritique{OverallScore: 10}, nil
+}
+
+type contextCapturingCritiquer struct {
+	contexts chan context.Context
+	release  chan struct{}
+}
+
+func (c *contextCapturingCritiquer) Ready(context.Context) error {
+	return nil
+}
+
+func (c *contextCapturingCritiquer) CritiqueRecipe(ctx context.Context, _ ai.Recipe) (*ai.RecipeCritique, error) {
+	c.contexts <- ctx
+	select {
+	case <-c.release:
+		return &ai.RecipeCritique{OverallScore: 10}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }


### PR DESCRIPTION
give background critique its own timeout. 