### PR TITLE
Skip recipe emails for users without a favorite store

### DIFF
--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -175,6 +175,10 @@ func (m *mailer) sendEmail(ctx context.Context, user utypes.User) {
 		slog.DebugContext(ctx, "user has not opted into mail", "user", user.ID)
 		return
 	}
+	if user.FavoriteStore == "" {
+		slog.DebugContext(ctx, "user has no favorite store", "user", user.ID)
+		return
+	}
 	ctx, cancel := context.WithTimeout(ctx, emailDeliveryTimeout)
 	defer cancel()
 

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -319,6 +319,15 @@ func TestSendEmailSkipsUsersWhoAreNotEligible(t *testing.T) {
 		m.sendEmail(context.Background(), utypes.User{ID: "user-1"})
 	})
 
+	t.Run("no favorite store", func(t *testing.T) {
+		m := &mailer{}
+		m.sendEmail(context.Background(), utypes.User{
+			ID:        "user-1",
+			MailOptIn: true,
+			Email:     []string{"u1@example.com"},
+		})
+	})
+
 	location := testMailLocation()
 	today, err := recipes.StoreToDate(context.Background(), time.Now(), location)
 	if err != nil {


### PR DESCRIPTION
### Motivation
- Prevent runtime errors during scheduled email runs by treating users without a favorite store as ineligible for recipe emails instead of attempting to prepare/send them.

### Description
- Add an early guard in `internal/mail/mail.go`'s `sendEmail` to return with a debug log when `user.FavoriteStore == ""` and add a unit test case in `internal/mail/mail_test.go` (`TestSendEmailSkipsUsersWhoAreNotEligible` — "no favorite store") to cover the regression.

### Testing
- Ran `gofmt`, `go test ./...`, and `go vet ./...` and observed tests and vet checks pass; `./task.sh fmt` and `./task.sh lint` could not be executed because the pinned `task` binary could not be downloaded from the Go proxy in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a92f954b8988329ab4ddf0814081b51)